### PR TITLE
Change the runtime to corretto8 for CodeBuild

### DIFF
--- a/buildspecs/buildspec.yml
+++ b/buildspecs/buildspec.yml
@@ -9,7 +9,7 @@ env:
 phases:
   install:
     runtime-versions:
-      java: openjdk8
+      java: corretto8
   build:
     commands:
       - ./gradlew build


### PR DESCRIPTION
AWS CodeBuild does not support openjdk8. Changed to corretto8. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
