### PR TITLE
Configure buildspec to start docker

### DIFF
--- a/buildspecs/buildspec.yml
+++ b/buildspecs/buildspec.yml
@@ -10,6 +10,11 @@ phases:
   install:
     runtime-versions:
       java: corretto8
+    commands:
+      # start docker
+      # https://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker-custom-image.html#sample-docker-custom-image-files
+      - nohup /usr/local/bin/dockerd --host=unix:///var/run/docker.sock --host=tcp://127.0.0.1:2375 --storage-driver=overlay2&
+      - timeout 15 sh -c "until docker info; do echo .; sleep 1; done"
   build:
     commands:
       - ./gradlew build


### PR DESCRIPTION
*Description of changes:*
- Fixed the issue that the current CodeBuild configure does not allow to start a docker.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
