### PR TITLE
Automate publish process

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -126,6 +126,11 @@ tasks.named('wrapper') {
 	distributionType = Wrapper.DistributionType.ALL
 }
 
+def repoUrl = "https://aws.oss.sonatype.org/service/local/staging/deploy/maven2/"
+def repoPassword = System.getenv('mavenPassword')
+def repoUserName = System.getenv('mavenUserName')
+
+
 publishing {
 	publications {
 		mavenJava(MavenPublication) {
@@ -153,19 +158,31 @@ publishing {
 						url = 'https://github.com/awslabs/aws-embedded-metrics-java/blob/master/LICENSE'
 					}
 				}
+				developers {
+					developer {
+						id = 'aws_emf'
+						name = 'AWS CloudWatch'
+						email = 'logs-emf@amazon.com'
+					}
+				}
 			}
 		}
 	}
 	repositories {
 		maven {
-			//TODO: update to Sonatype repo
-			def releasesRepoUrl = "$buildDir/repos/releases"
-			def snapshotsRepoUrl = "$buildDir/repos/snapshots"
-			url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
+			name = "mavenRepo"
+			url = repoUrl
+			credentials {
+				username = repoUserName
+				password = repoPassword
+			}
 		}
 	}
 }
 
 signing {
+	def signingKey = findProperty("signingKey")
+	def signingPassword = findProperty("signingPassword")
+	useInMemoryPgpKeys(signingKey, signingPassword)
 	sign publishing.publications.mavenJava
 }

--- a/buildspecs/buildspec.release.yml
+++ b/buildspecs/buildspec.release.yml
@@ -1,0 +1,17 @@
+version: 0.2
+
+env:
+  variables:
+    AWS_REGION: us-west-2
+  parameter-store:
+    ORG_GRADLE_PROJECT_signingKey: emf_java_signing_key
+    ORG_GRADLE_PROJECT_signingPassword: emf_java_signing_password
+    mavenUserName: mavenUserName
+    mavenPassword: mavenPassword
+phases:
+  install:
+    runtime-versions:
+      java: corretto8
+  build:
+    commands:
+      - ./gradlew publish


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Added a CodeBuild build spec for automating the publish process.
- After add a stage to run from buildspec.release.yml, the artifacts would be published to the staging repo. However, for now, the state of promoting from a staging repo to the public maven repo has to be run manually. This I believe is due to some constraints on the AWS maven namespace. I'll figure out if the whole release process can be automated

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
