### PR TITLE
Fixed a bug in the EnvironmentProvider

### DIFF
--- a/canarytests/agent/src/main/java/emf/canary/ECSRunnable.java
+++ b/canarytests/agent/src/main/java/emf/canary/ECSRunnable.java
@@ -21,7 +21,8 @@ public class ECSRunnable implements Runnable {
         }
         Configuration config = EnvironmentConfigurationProvider.getConfig();
         config.setLogGroupName("/Canary/Java/CloudWatchAgent/Metrics");
-        logger.putDimensions(
+        logger.setNamespace("Canary");
+        logger.setDimensions(
                 DimensionSet.of(
                         "Runtime", "Java8",
                         "Platform", "ECS",

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/environment/EnvironmentProvider.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/environment/EnvironmentProvider.java
@@ -35,7 +35,7 @@ public class EnvironmentProvider {
     // Ordering of this array matters
     private final Environment[] environments =
             new Environment[] {
-                lambdaEnvironment, ec2Environment, ecsEnvironment, defaultEnvironment
+                lambdaEnvironment, ecsEnvironment, ec2Environment, defaultEnvironment
             };
 
     public CompletableFuture<Environment> resolveEnvironment() {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Fixed a bug that in ECS environment, the EnvironmentProvider may return EC2 environment. This was caused the provider would try to probe EC2 environment first.
- Override the default dimension in the ECS examble

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
