### PR TITLE
Fixed the bug that lambda function is blocked

### DIFF
--- a/src/main/java/software/amazon/cloudwatchlogs/emf/environment/EnvironmentProvider.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/environment/EnvironmentProvider.java
@@ -16,6 +16,8 @@
 
 package software.amazon.cloudwatchlogs.emf.environment;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import lombok.AllArgsConstructor;
@@ -49,13 +51,12 @@ public class EnvironmentProvider {
             return CompletableFuture.completedFuture(cachedEnvironment);
         }
 
-        CompletableFuture<Optional<EnvironmentResolveResult>> resolvedEnv =
+        CompletableFuture<Optional<Environment>> resolvedEnv =
                 discoverEnvironmentAsync();
 
         return resolvedEnv.thenApply(
                 optionalEnv ->
                         optionalEnv
-                                .map(EnvironmentResolveResult::getEnvironment)
                                 .orElseGet(
                                         () -> {
                                             cachedEnvironment = defaultEnvironment;
@@ -72,27 +73,28 @@ public class EnvironmentProvider {
         cachedEnvironment = null;
     }
 
-    private CompletableFuture<Optional<EnvironmentResolveResult>> discoverEnvironmentAsync() {
+    private CompletableFuture<Optional<Environment>> discoverEnvironmentAsync() {
 
-        CompletableFuture<Optional<EnvironmentResolveResult>> ans =
-                CompletableFuture.completedFuture(Optional.empty());
+        CompletableFuture<Optional<Environment>> ans = new CompletableFuture<>();
+
+        List<CompletableFuture<EnvironmentResolveResult>> futures  = new ArrayList<>();
         for (Environment env : environments) {
             CompletableFuture<EnvironmentResolveResult> future =
                     CompletableFuture.supplyAsync(
                             () -> new EnvironmentResolveResult(env.probe(), env));
-            ans =
-                    ans.thenCombine(
-                            future,
-                            (optionalEnv, envResult) -> {
-                                if (optionalEnv.isPresent()) {
-                                    return optionalEnv;
-                                }
-                                if (envResult.isCandidate) {
-                                    return Optional.of(envResult);
-                                }
-                                return Optional.empty();
-                            });
+            futures.add(future);
         }
+
+        CompletableFuture.runAsync(() -> {
+            for(CompletableFuture<EnvironmentResolveResult> future: futures) {
+                EnvironmentResolveResult result = future.join();
+                if (result.isCandidate) {
+                    ans.complete(Optional.of(result.environment));
+                    return;
+                }
+            }
+            ans.complete(Optional.empty());
+        });
 
         return ans;
     }

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/environment/EnvironmentProvider.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/environment/EnvironmentProvider.java
@@ -51,17 +51,15 @@ public class EnvironmentProvider {
             return CompletableFuture.completedFuture(cachedEnvironment);
         }
 
-        CompletableFuture<Optional<Environment>> resolvedEnv =
-                discoverEnvironmentAsync();
+        CompletableFuture<Optional<Environment>> resolvedEnv = discoverEnvironmentAsync();
 
         return resolvedEnv.thenApply(
                 optionalEnv ->
-                        optionalEnv
-                                .orElseGet(
-                                        () -> {
-                                            cachedEnvironment = defaultEnvironment;
-                                            return cachedEnvironment;
-                                        }));
+                        optionalEnv.orElseGet(
+                                () -> {
+                                    cachedEnvironment = defaultEnvironment;
+                                    return cachedEnvironment;
+                                }));
     }
 
     public Environment getDefaultEnvironment() {
@@ -77,7 +75,7 @@ public class EnvironmentProvider {
 
         CompletableFuture<Optional<Environment>> ans = new CompletableFuture<>();
 
-        List<CompletableFuture<EnvironmentResolveResult>> futures  = new ArrayList<>();
+        List<CompletableFuture<EnvironmentResolveResult>> futures = new ArrayList<>();
         for (Environment env : environments) {
             CompletableFuture<EnvironmentResolveResult> future =
                     CompletableFuture.supplyAsync(
@@ -85,16 +83,17 @@ public class EnvironmentProvider {
             futures.add(future);
         }
 
-        CompletableFuture.runAsync(() -> {
-            for(CompletableFuture<EnvironmentResolveResult> future: futures) {
-                EnvironmentResolveResult result = future.join();
-                if (result.isCandidate) {
-                    ans.complete(Optional.of(result.environment));
-                    return;
-                }
-            }
-            ans.complete(Optional.empty());
-        });
+        CompletableFuture.runAsync(
+                () -> {
+                    for (CompletableFuture<EnvironmentResolveResult> future : futures) {
+                        EnvironmentResolveResult result = future.join();
+                        if (result.isCandidate) {
+                            ans.complete(Optional.of(result.environment));
+                            return;
+                        }
+                    }
+                    ans.complete(Optional.empty());
+                });
 
         return ans;
     }

--- a/src/test/java/software/amazon/cloudwatchlogs/emf/environment/EnvironmentProviderTest.java
+++ b/src/test/java/software/amazon/cloudwatchlogs/emf/environment/EnvironmentProviderTest.java
@@ -180,13 +180,15 @@ public class EnvironmentProviderTest {
         EC2Environment mockedEC2Env = mock(EC2Environment.class);
         when(mockedEC2Env.probe()).thenReturn(true);
         DefaultEnvironment mockedDefaultEnv = mock(DefaultEnvironment.class);
-        when(mockedDefaultEnv.probe()).thenAnswer(new Answer<Boolean>() {
-            @Override
-            public Boolean answer(InvocationOnMock invocation) throws Throwable {
-                Thread.sleep(5_000);
-                return true;
-            }
-        });
+        when(mockedDefaultEnv.probe())
+                .thenAnswer(
+                        new Answer<Boolean>() {
+                            @Override
+                            public Boolean answer(InvocationOnMock invocation) throws Throwable {
+                                Thread.sleep(5_000);
+                                return true;
+                            }
+                        });
         Environment[] envs = new Environment[] {mockedLambdaEnv, mockedDefaultEnv, mockedEC2Env};
 
         FieldSetter.setField(

--- a/src/test/java/software/amazon/cloudwatchlogs/emf/environment/EnvironmentProviderTest.java
+++ b/src/test/java/software/amazon/cloudwatchlogs/emf/environment/EnvironmentProviderTest.java
@@ -28,6 +28,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.internal.util.reflection.FieldSetter;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
@@ -167,5 +169,32 @@ public class EnvironmentProviderTest {
         Environment expectedEnv = environmentProvider.resolveEnvironment().join();
         assertSame(expectedEnv, mockedEC2Env);
         environmentProvider.cleanResolvedEnvironment();
+    }
+
+    @Test
+    public void testResolveEnvironmentReturnFirstDetectedEnvironment() throws Exception {
+
+        long startTime = System.currentTimeMillis();
+        LambdaEnvironment mockedLambdaEnv = mock(LambdaEnvironment.class);
+        when(mockedLambdaEnv.probe()).thenReturn(true);
+        EC2Environment mockedEC2Env = mock(EC2Environment.class);
+        when(mockedEC2Env.probe()).thenReturn(true);
+        DefaultEnvironment mockedDefaultEnv = mock(DefaultEnvironment.class);
+        when(mockedDefaultEnv.probe()).thenAnswer(new Answer<Boolean>() {
+            @Override
+            public Boolean answer(InvocationOnMock invocation) throws Throwable {
+                Thread.sleep(5_000);
+                return true;
+            }
+        });
+        Environment[] envs = new Environment[] {mockedLambdaEnv, mockedDefaultEnv, mockedEC2Env};
+
+        FieldSetter.setField(
+                environmentProvider,
+                EnvironmentProvider.class.getDeclaredField("environments"),
+                envs);
+        Environment env = environmentProvider.resolveEnvironment().join();
+        assertSame(env, mockedLambdaEnv);
+        assertTrue(System.currentTimeMillis() - startTime < 3_000);
     }
 }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/aws-embedded-metrics-java/issues/33

*Description of changes:*
The bug was caused by the completeness of resolving lambda environment depends on the result of detecting EC2Environment due to the use of CompletableFuture.thenCombine().
The issue was fixed by check the completeness of each future asynchronously.

*Testing
Added a new unit test to verify the resolve of environments does not blocked by the resolve of other environments that appears latter in the environment list.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
