### PR TITLE
Handle log context with more than 100 metrics

### DIFF
--- a/src/main/java/software/amazon/cloudwatchlogs/emf/Constants.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/Constants.java
@@ -20,4 +20,6 @@ public class Constants {
     public static final int DEFAULT_AGENT_PORT = 25888;
 
     public static final String UNKNOWN = "Unknown";
+
+    public static final int MAX_METRICS_PER_EVENT = 100;
 }

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/model/Metadata.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/model/Metadata.java
@@ -26,12 +26,15 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
+import lombok.With;
 import software.amazon.cloudwatchlogs.emf.serializers.InstantDeserializer;
 import software.amazon.cloudwatchlogs.emf.serializers.InstantSerializer;
 
 /** Represents the MetaData part of the EMF schema. */
+@AllArgsConstructor
 class Metadata {
 
     @Getter
@@ -44,6 +47,7 @@ class Metadata {
 
     @Getter
     @Setter
+    @With
     @JsonProperty("CloudWatchMetrics")
     private List<MetricDirective> cloudWatchMetrics;
 

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/model/MetricDefinition.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/model/MetricDefinition.java
@@ -16,13 +16,16 @@
 
 package software.amazon.cloudwatchlogs.emf.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NonNull;
-import lombok.Setter;
 import software.amazon.cloudwatchlogs.emf.serializers.UnitDeserializer;
 import software.amazon.cloudwatchlogs.emf.serializers.UnitSerializer;
 
@@ -30,19 +33,31 @@ import software.amazon.cloudwatchlogs.emf.serializers.UnitSerializer;
 @AllArgsConstructor
 class MetricDefinition {
     @NonNull
-    @Setter
     @Getter
     @JsonProperty("Name")
     private String name;
 
-    @Setter
     @Getter
     @JsonProperty("Unit")
     @JsonSerialize(using = UnitSerializer.class)
     @JsonDeserialize(using = UnitDeserializer.class)
     private Unit unit;
 
+    @JsonIgnore @NonNull @Getter private List<Double> values;
+
     MetricDefinition(String name) {
-        this(name, Unit.NONE);
+        this(name, Unit.NONE, new ArrayList<>());
+    }
+
+    MetricDefinition(String name, double value) {
+        this(name, Unit.NONE, value);
+    }
+
+    MetricDefinition(String name, Unit unit, double value) {
+        this(name, unit, new ArrayList<>(Arrays.asList(value)));
+    }
+
+    void addValue(double value) {
+        values.add(value);
     }
 }

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/model/MetricsContext.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/model/MetricsContext.java
@@ -17,10 +17,9 @@
 package software.amazon.cloudwatchlogs.emf.model;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import lombok.Getter;
+import software.amazon.cloudwatchlogs.emf.Constants;
 
 /** Stores metrics and their associated properties and dimensions. */
 public class MetricsContext {
@@ -101,8 +100,7 @@ public class MetricsContext {
      * @param unit The unit of the metric
      */
     public void putMetric(String key, double value, Unit unit) {
-        metricDirective.putMetric(new MetricDefinition(key, unit));
-        rootNode.putMetric(key, value);
+        metricDirective.putMetric(key, value, unit);
     }
 
     /**
@@ -201,12 +199,38 @@ public class MetricsContext {
     }
 
     /**
-     * Serialize the metrics in this context to a string.
+     * Serialize the metrics in this context to strings.
      *
-     * @return the serialized string
+     * @return the serialized strings.
      * @throws JsonProcessingException if there's any object that cannot be serialized
      */
-    public String serialize() throws JsonProcessingException {
-        return this.rootNode.serialize();
+    public List<String> serialize() throws JsonProcessingException {
+        if (rootNode.metrics().size() <= Constants.MAX_METRICS_PER_EVENT) {
+            return Arrays.asList(this.rootNode.serialize());
+        } else {
+            List<RootNode> nodes = new ArrayList<>();
+            Map<String, MetricDefinition> metrics = new HashMap<>();
+            int count = 0;
+            for (MetricDefinition metric : rootNode.metrics().values()) {
+                metrics.put(metric.getName(), metric);
+                count++;
+                if (metrics.size() == Constants.MAX_METRICS_PER_EVENT
+                        || count == rootNode.metrics().size()) {
+                    Metadata metadata = rootNode.getAws();
+                    MetricDirective metricDirective = metadata.getCloudWatchMetrics().get(0);
+                    Metadata clonedMetadata =
+                            metadata.withCloudWatchMetrics(
+                                    Arrays.asList(metricDirective.withMetrics(metrics)));
+                    nodes.add(rootNode.withAws(clonedMetadata));
+                    metrics = new HashMap<>();
+                }
+            }
+
+            List<String> strings = new ArrayList<>();
+            for (RootNode node : nodes) {
+                strings.add(node.serialize());
+            }
+            return strings;
+        }
     }
 }

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/model/MetricsContext.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/model/MetricsContext.java
@@ -199,7 +199,9 @@ public class MetricsContext {
     }
 
     /**
-     * Serialize the metrics in this context to strings.
+     * Serialize the metrics in this context to strings. The EMF backend requires no more than 100
+     * metrics in one log event. If there're more than 100 metrics, we split the metrics into
+     * multiple log events.
      *
      * @return the serialized strings.
      * @throws JsonProcessingException if there's any object that cannot be serialized

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/model/RootNode.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/model/RootNode.java
@@ -25,7 +25,6 @@ import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.With;
@@ -65,13 +64,11 @@ class RootNode {
         Map<String, Object> targetMembers = new HashMap<>();
         targetMembers.putAll(properties);
         targetMembers.putAll(getDimensions());
-        List<MetricDefinition> metrics =
-                aws.getCloudWatchMetrics().stream()
-                        .flatMap(metricDirective -> metricDirective.getMetrics().values().stream())
-                        .collect(Collectors.toList());
-        for (MetricDefinition metric : metrics) {
-            List<Double> values = metric.getValues();
-            targetMembers.put(metric.getName(), values.size() == 1 ? values.get(0) : values);
+        for (MetricDirective metricDirective : aws.getCloudWatchMetrics()) {
+            for (MetricDefinition metric : metricDirective.getMetrics().values()) {
+                List<Double> values = metric.getValues();
+                targetMembers.put(metric.getName(), values.size() == 1 ? values.get(0) : values);
+            }
         }
         return targetMembers;
     }

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/serializers/InstantSerializer.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/serializers/InstantSerializer.java
@@ -37,7 +37,6 @@ public class InstantSerializer extends StdSerializer<Instant> {
     public void serialize(Instant value, JsonGenerator jgen, SerializerProvider provider)
             throws IOException, JsonProcessingException {
 
-        // Just serialize dimensions as an array.
         jgen.writeNumber(value.toEpochMilli());
     }
 }

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/sinks/AgentSink.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/sinks/AgentSink.java
@@ -48,7 +48,9 @@ public class AgentSink implements ISink {
         }
 
         try {
-            client.sendMessage(context.serialize() + "\n");
+            for (String event : context.serialize()) {
+                client.sendMessage(event + "\n");
+            }
         } catch (JsonProcessingException e) {
             log.error("Failed to serialize the metrics with the exception: ", e);
         }

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/sinks/ConsoleSink.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/sinks/ConsoleSink.java
@@ -33,7 +33,9 @@ public class ConsoleSink implements ISink {
 
         try {
             // CHECKSTYLE OFF
-            System.out.println(context.serialize());
+            for (String event : context.serialize()) {
+                System.out.println(event);
+            }
             // CHECKSTYLE ON
         } catch (JsonProcessingException e) {
             log.error("Failed to serialize a MetricsContext: ", e);

--- a/src/test/java/software/amazon/cloudwatchlogs/emf/model/MetricDefinitionTest.java
+++ b/src/test/java/software/amazon/cloudwatchlogs/emf/model/MetricDefinitionTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertEquals;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Arrays;
 import org.junit.Test;
 
 public class MetricDefinitionTest {
@@ -41,9 +42,18 @@ public class MetricDefinitionTest {
     @Test
     public void testSerializeMetricDefinition() throws JsonProcessingException {
         ObjectMapper objectMapper = new ObjectMapper();
-        MetricDefinition metricDefinition = new MetricDefinition("Time", Unit.MILLISECONDS);
+        MetricDefinition metricDefinition = new MetricDefinition("Time", Unit.MILLISECONDS, 10);
         String metricString = objectMapper.writeValueAsString(metricDefinition);
 
         assertEquals(metricString, "{\"Name\":\"Time\",\"Unit\":\"Milliseconds\"}");
+    }
+
+    @Test
+    public void testAddValue() {
+        MetricDefinition md = new MetricDefinition("Time", Unit.MICROSECONDS, 10);
+        assertEquals(Arrays.asList(10d), md.getValues());
+
+        md.addValue(20);
+        assertEquals(Arrays.asList(10d, 20d), md.getValues());
     }
 }

--- a/src/test/java/software/amazon/cloudwatchlogs/emf/model/MetricDirectiveTest.java
+++ b/src/test/java/software/amazon/cloudwatchlogs/emf/model/MetricDirectiveTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertEquals;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Arrays;
 import org.junit.Test;
 
 public class MetricDirectiveTest {
@@ -50,13 +51,38 @@ public class MetricDirectiveTest {
     @Test
     public void testPutMetric() throws JsonProcessingException {
         MetricDirective metricDirective = new MetricDirective();
-        metricDirective.putMetric(new MetricDefinition("Time"));
+        metricDirective.putMetric("Time", 10);
 
         String serializedMetricDirective = objectMapper.writeValueAsString(metricDirective);
 
         assertEquals(
                 serializedMetricDirective,
                 "{\"Namespace\":\"aws-embedded-metrics\",\"Metrics\":[{\"Name\":\"Time\",\"Unit\":\"None\"}],\"Dimensions\":[[]]}");
+    }
+
+    @Test
+    public void testPutSameMetricMultipleTimes() {
+        MetricDirective metricDirective = new MetricDirective();
+        metricDirective.putMetric("Time", 10);
+        metricDirective.putMetric("Time", 20);
+
+        assertEquals(1, metricDirective.getAllMetrics().size());
+        MetricDefinition[] mds = metricDirective.getAllMetrics().toArray(new MetricDefinition[0]);
+        assertEquals(mds[0].getValues(), Arrays.asList(10d, 20d));
+    }
+
+    @Test
+    public void testPutMetricWithoutUnit() {
+        MetricDirective metricDirective = new MetricDirective();
+        metricDirective.putMetric("Time", 10);
+        assertEquals(metricDirective.getMetrics().get("Time").getUnit(), Unit.NONE);
+    }
+
+    @Test
+    public void testPutMetricWithUnit() {
+        MetricDirective metricDirective = new MetricDirective();
+        metricDirective.putMetric("Time", 10, Unit.MILLISECONDS);
+        assertEquals(metricDirective.getMetrics().get("Time").getUnit(), Unit.MILLISECONDS);
     }
 
     @Test

--- a/src/test/java/software/amazon/cloudwatchlogs/emf/model/MetricsContextTest.java
+++ b/src/test/java/software/amazon/cloudwatchlogs/emf/model/MetricsContextTest.java
@@ -17,6 +17,7 @@
 package software.amazon.cloudwatchlogs.emf.model;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -72,6 +73,22 @@ public class MetricsContextTest {
             assertEquals(originalMetric.getName(), metric.getName());
             assertEquals(originalMetric.getUnit(), metric.getUnit());
         }
+    }
+
+    @Test
+    public void testSerializeZeroMetric() throws JsonProcessingException {
+        MetricsContext mc = new MetricsContext();
+        mc.putDimension(DimensionSet.of("Region", "IAD"));
+        List<String> events = mc.serialize();
+
+        int expectedEventCount = 1;
+        assertEquals(expectedEventCount, events.size());
+
+        JsonMapper objectMapper = new JsonMapper();
+        Map<String, Object> metadata_map =
+                objectMapper.readValue(events.get(0), new TypeReference<Map<String, Object>>() {});
+        // If there's no metric added, the _aws would be filtered out from the log event
+        assertFalse(metadata_map.containsKey("_aws"));
     }
 
     @SuppressWarnings("unchecked")

--- a/src/test/java/software/amazon/cloudwatchlogs/emf/model/MetricsContextTest.java
+++ b/src/test/java/software/amazon/cloudwatchlogs/emf/model/MetricsContextTest.java
@@ -1,0 +1,97 @@
+/*
+ *   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package software.amazon.cloudwatchlogs.emf.model;
+
+import static org.junit.Assert.assertEquals;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+
+public class MetricsContextTest {
+
+    @Test
+    public void testSerializeLessThan100Metrics() throws JsonProcessingException {
+        MetricsContext mc = new MetricsContext();
+        int metricCount = 10;
+        for (int i = 0; i < metricCount; i++) {
+            String key = "Metric-" + i;
+            mc.putMetric(key, i);
+        }
+
+        List<String> events = mc.serialize();
+        assertEquals(1, events.size());
+
+        List<MetricDefinition> metrics = parseMetrics(events.get(0));
+        assertEquals(metrics.size(), metricCount);
+        for (MetricDefinition metric : metrics) {
+            MetricDefinition originalMetric = mc.getRootNode().metrics().get(metric.getName());
+            assertEquals(originalMetric.getName(), metric.getName());
+            assertEquals(originalMetric.getUnit(), metric.getUnit());
+        }
+    }
+
+    @Test
+    public void testSerializeMoreThen100Metrics() throws JsonProcessingException {
+        MetricsContext mc = new MetricsContext();
+        int metricCount = 253;
+        int expectedEventCount = 3;
+        for (int i = 0; i < metricCount; i++) {
+            String key = "Metric-" + i;
+            mc.putMetric(key, i);
+        }
+
+        List<String> events = mc.serialize();
+        assertEquals(expectedEventCount, events.size());
+
+        List<MetricDefinition> allMetrics = new ArrayList<>();
+        for (String event : events) {
+            allMetrics.addAll(parseMetrics(event));
+        }
+        assertEquals(metricCount, allMetrics.size());
+        for (MetricDefinition metric : allMetrics) {
+            MetricDefinition originalMetric = mc.getRootNode().metrics().get(metric.getName());
+            assertEquals(originalMetric.getName(), metric.getName());
+            assertEquals(originalMetric.getUnit(), metric.getUnit());
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private ArrayList<MetricDefinition> parseMetrics(String event) throws JsonProcessingException {
+        JsonMapper objectMapper = new JsonMapper();
+        Map<String, Object> metadata_map =
+                objectMapper.readValue(event, new TypeReference<Map<String, Object>>() {});
+        Map<String, Object> metadata = (Map<String, Object>) metadata_map.get("_aws");
+        ArrayList<Map<String, Object>> metricDirectives =
+                (ArrayList<Map<String, Object>>) metadata.get("CloudWatchMetrics");
+        ArrayList<Map<String, String>> metrics =
+                (ArrayList<Map<String, String>>) metricDirectives.get(0).get("Metrics");
+
+        ArrayList<MetricDefinition> metricDefinitions = new ArrayList<>();
+        for (Map<String, String> metric : metrics) {
+            String name = metric.get("Name");
+            Unit unit = Unit.fromValue(metric.get("Unit"));
+            double value = (double) metadata_map.get(name);
+            metricDefinitions.add(new MetricDefinition(name, unit, value));
+        }
+        return metricDefinitions;
+    }
+}

--- a/src/test/java/software/amazon/cloudwatchlogs/emf/model/RootNodeTest.java
+++ b/src/test/java/software/amazon/cloudwatchlogs/emf/model/RootNodeTest.java
@@ -23,27 +23,11 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import org.junit.Test;
 
 public class RootNodeTest {
-
-    @Test
-    public void testPutMetric() {
-        RootNode rootNode = new RootNode();
-        rootNode.putMetric("Time", 10.0);
-
-        assertEquals(rootNode.getTargetMembers().get("Time"), 10.0);
-    }
-
-    @Test
-    public void testPutSameMetricMultipleTimes() {
-        RootNode rootNode = new RootNode();
-        rootNode.putMetric("Time", 10.0);
-        rootNode.putMetric("Time", 20.0);
-
-        assertEquals(rootNode.getTargetMembers().get("Time"), Arrays.asList(10.0, 20.0));
-    }
 
     @Test
     public void testPutProperty() {
@@ -103,9 +87,10 @@ public class RootNodeTest {
         mc.putProperty("Property", "PropertyValue");
 
         ObjectMapper objectMapper = new ObjectMapper();
-        String emf_log = mc.serialize();
+        List<String> emf_logs = mc.serialize();
         Map<String, Object> emf_map =
-                objectMapper.readValue(emf_log, new TypeReference<Map<String, Object>>() {});
+                objectMapper.readValue(
+                        emf_logs.get(0), new TypeReference<Map<String, Object>>() {});
 
         assertEquals(emf_map.keySet().size(), 5);
         assertEquals(emf_map.get("Region"), "us-east-1");


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/aws-embedded-metrics-java/issues/41

*Description of changes:*
Handle the case that there're more than 100 metrics in a metric context. The metrics would be split into multiple log event message in this case. There would be 100 metrics in the first several log message and the last one may have less than 100 log messages. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
