### PR TITLE
Fixed failed testcases

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ allprojects {
 		targetCompatibility = '1.8'
 	}
 
-	version = '1.0.0'
+	version = '1.0.1'
 }
 
 java {

--- a/src/test/java/software/amazon/cloudwatchlogs/emf/model/MetricDirectiveTest.java
+++ b/src/test/java/software/amazon/cloudwatchlogs/emf/model/MetricDirectiveTest.java
@@ -19,12 +19,14 @@ package software.amazon.cloudwatchlogs.emf.model;
 import static org.junit.Assert.assertEquals;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Arrays;
 import org.junit.Test;
 
 public class MetricDirectiveTest {
-    private ObjectMapper objectMapper = new ObjectMapper();
+    private ObjectMapper objectMapper =
+            new ObjectMapper().configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true);
 
     @Test
     public void testDefaultNamespace() throws JsonProcessingException {
@@ -33,7 +35,7 @@ public class MetricDirectiveTest {
 
         assertEquals(
                 serializedMetricDirective,
-                "{\"Namespace\":\"aws-embedded-metrics\",\"Metrics\":[],\"Dimensions\":[[]]}");
+                "{\"Dimensions\":[[]],\"Metrics\":[],\"Namespace\":\"aws-embedded-metrics\"}");
     }
 
     @Test
@@ -45,7 +47,7 @@ public class MetricDirectiveTest {
 
         assertEquals(
                 serializedMetricDirective,
-                "{\"Namespace\":\"test-lambda-metrics\",\"Metrics\":[],\"Dimensions\":[[]]}");
+                "{\"Dimensions\":[[]],\"Metrics\":[],\"Namespace\":\"test-lambda-metrics\"}");
     }
 
     @Test
@@ -57,7 +59,7 @@ public class MetricDirectiveTest {
 
         assertEquals(
                 serializedMetricDirective,
-                "{\"Namespace\":\"aws-embedded-metrics\",\"Metrics\":[{\"Name\":\"Time\",\"Unit\":\"None\"}],\"Dimensions\":[[]]}");
+                "{\"Dimensions\":[[]],\"Metrics\":[{\"Name\":\"Time\",\"Unit\":\"None\"}],\"Namespace\":\"aws-embedded-metrics\"}");
     }
 
     @Test
@@ -95,7 +97,7 @@ public class MetricDirectiveTest {
 
         assertEquals(
                 serializedMetricDirective,
-                "{\"Namespace\":\"aws-embedded-metrics\",\"Metrics\":[],\"Dimensions\":[[\"Region\",\"Instance\"]]}");
+                "{\"Dimensions\":[[\"Region\",\"Instance\"]],\"Metrics\":[],\"Namespace\":\"aws-embedded-metrics\"}");
     }
 
     @Test
@@ -108,7 +110,7 @@ public class MetricDirectiveTest {
 
         assertEquals(
                 serializedMetricDirective,
-                "{\"Namespace\":\"aws-embedded-metrics\",\"Metrics\":[],\"Dimensions\":[[\"Region\"],[\"Instance\"]]}");
+                "{\"Dimensions\":[[\"Region\"],[\"Instance\"]],\"Metrics\":[],\"Namespace\":\"aws-embedded-metrics\"}");
     }
 
     @Test
@@ -122,6 +124,6 @@ public class MetricDirectiveTest {
 
         assertEquals(
                 serializedMetricDirective,
-                "{\"Namespace\":\"aws-embedded-metrics\",\"Metrics\":[],\"Dimensions\":[[\"Version\",\"Region\"],[\"Version\",\"Instance\"]]}");
+                "{\"Dimensions\":[[\"Version\",\"Region\"],[\"Version\",\"Instance\"]],\"Metrics\":[],\"Namespace\":\"aws-embedded-metrics\"}");
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
When Jackson serializes an object, there's no fixed order for the fields of the object. Thus, this causes test cases failure.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
