### PR TITLE
in usage, link to artifact and import Unit

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ To use a metric logger, you need to manually create and flush the logger.
 ```java
 import software.amazon.cloudwatchlogs.emf.logger.MetricsLogger;
 import software.amazon.cloudwatchlogs.emf.model.DimensionSet;
+import software.amazon.cloudwatchlogs.emf.model.Unit;
 
 class Example {
 	public static void main(String[] args) {
@@ -39,6 +40,11 @@ class Example {
 	}
 }
 ```
+
+You can find the artifact location and examples of how to include it in your project at Maven Central:
+
+https://search.maven.org/artifact/software.amazon.cloudwatchlogs/aws-embedded-metrics
+
 
 ## API
 


### PR DESCRIPTION
~*Issue #, if available:*~

*Description of changes:* It was a little difficult to find the actual artifact location, so I figured it might be helpful to include that in the README.

As a drive-by, I've included the import for the `Unit` class in the usage example.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice now and forever.
