### PR TITLE
Fixed an issue that the resolved environment was not cached

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@
 
 plugins {
 	id 'java-library'
-	id 'com.diffplug.spotless' version '5.1.0'
+	id 'com.diffplug.spotless' version '5.8.2'
 	id 'maven-publish'
 	id 'signing'
 }

--- a/examples/lambda/build.gradle
+++ b/examples/lambda/build.gradle
@@ -9,6 +9,10 @@ repositories {
 
 dependencies {
     implementation 'com.amazonaws:aws-lambda-java-core:1.2.1'
+    implementation  "org.apache.logging.log4j:log4j-api:2.13.3"
+    implementation "org.apache.logging.log4j:log4j-core:2.13.3"
+    implementation "org.apache.logging.log4j:log4j-slf4j-impl:2.13.3"
+    implementation 'com.amazonaws:aws-lambda-java-log4j2:1.2.0'
     implementation rootProject
         
 }

--- a/examples/lambda/src/main/resources/log4j2.xml
+++ b/examples/lambda/src/main/resources/log4j2.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+  ~
+  ~   Licensed under the Apache License, Version 2.0 (the "License").
+  ~   You may not use this file except in compliance with the License.
+  ~   You may obtain a copy of the License at
+  ~
+  ~       http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~   Unless required by applicable law or agreed to in writing, software
+  ~   distributed under the License is distributed on an "AS IS" BASIS,
+  ~   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~   See the License for the specific language governing permissions and
+  ~   limitations under the License.
+  -->
+
+<Configuration packages="com.amazonaws.services.lambda.runtime.log4j2.LambdaAppender">
+    <Appenders>
+        <Lambda name="Lambda">
+            <PatternLayout>
+                <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1}:%L - %m%n</pattern>
+            </PatternLayout>
+        </Lambda>
+    </Appenders>
+    <Loggers>
+        <Root level="debug">
+            <AppenderRef ref="Lambda" />
+        </Root>
+    </Loggers>
+</Configuration>

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/environment/EnvironmentProvider.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/environment/EnvironmentProvider.java
@@ -54,12 +54,10 @@ public class EnvironmentProvider {
         CompletableFuture<Optional<Environment>> resolvedEnv = discoverEnvironmentAsync();
 
         return resolvedEnv.thenApply(
-                optionalEnv ->
-                        optionalEnv.orElseGet(
-                                () -> {
-                                    cachedEnvironment = defaultEnvironment;
-                                    return cachedEnvironment;
-                                }));
+                optionalEnv -> {
+                    cachedEnvironment = optionalEnv.orElse(defaultEnvironment);
+                    return cachedEnvironment;
+                });
     }
 
     public Environment getDefaultEnvironment() {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Fixed a bug that a resolved environment was not cached
* Added Log4j configuration for the Lambda example
* Updated spotless to version 5.8.2

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
