### PR TITLE
Allow putDimensionSet after setDimensions

### DIFF
--- a/src/main/java/software/amazon/cloudwatchlogs/emf/model/MetricDirective.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/model/MetricDirective.java
@@ -86,7 +86,7 @@ class MetricDirective {
      */
     void setDimensions(List<DimensionSet> dimensionSets) {
         shouldUseDefaultDimension = false;
-        dimensions = dimensionSets;
+        dimensions = new ArrayList<>(dimensionSets);
     }
 
     /**

--- a/src/test/java/software/amazon/cloudwatchlogs/emf/model/MetricDirectiveTest.java
+++ b/src/test/java/software/amazon/cloudwatchlogs/emf/model/MetricDirectiveTest.java
@@ -22,6 +22,8 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Arrays;
+import java.util.Collections;
+
 import org.junit.Test;
 
 public class MetricDirectiveTest {
@@ -125,5 +127,19 @@ public class MetricDirectiveTest {
         assertEquals(
                 serializedMetricDirective,
                 "{\"Dimensions\":[[\"Version\",\"Region\"],[\"Version\",\"Instance\"]],\"Metrics\":[],\"Namespace\":\"aws-embedded-metrics\"}");
+    }
+
+    @Test
+    public void testPutDimensionsAfterSetDimensions() throws JsonProcessingException {
+        MetricDirective metricDirective = new MetricDirective();
+        metricDirective.setDimensions(Collections.singletonList(DimensionSet.of("Version", "1")));
+        metricDirective.putDimensionSet(DimensionSet.of("Region", "us-east-1"));
+        metricDirective.putDimensionSet(DimensionSet.of("Instance", "inst-1"));
+
+        String serializedMetricDirective = objectMapper.writeValueAsString(metricDirective);
+
+        assertEquals(
+                serializedMetricDirective,
+                "{\"Dimensions\":[[\"Version\"],[\"Region\"],[\"Instance\"]],\"Metrics\":[],\"Namespace\":\"aws-embedded-metrics\"}");
     }
 }


### PR DESCRIPTION
Before this change, if you call MetricDirective.setDimensions and
then MetricDirective.putDimensionSet, you get UnsupportedOperationException.
With this change, everything works as expected.

*Issue #, if available:*

59

*Description of changes:*

Commit message has a description.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
