### PR TITLE
Issue 66: Changed the RootNode constructor so that the ObjectMapper i…

### DIFF
--- a/src/main/java/software/amazon/cloudwatchlogs/emf/model/RootNode.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/model/RootNode.java
@@ -36,17 +36,16 @@ class RootNode {
     @Getter
     @With
     @JsonProperty("_aws")
-    private Metadata aws;
+    private final Metadata aws;
 
     private Map<String, Object> properties;
-    private ObjectMapper objectMapper;
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+    private static final SimpleFilterProvider filterProvider =
+            new SimpleFilterProvider().addFilter("emptyMetricFilter", new EmptyMetricsFilter());
 
     RootNode() {
-        final SimpleFilterProvider filterProvider =
-                new SimpleFilterProvider().addFilter("emptyMetricFilter", new EmptyMetricsFilter());
         aws = new Metadata();
         properties = new HashMap<>();
-        objectMapper = new ObjectMapper();
         objectMapper.setFilterProvider(filterProvider);
     }
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/aws-embedded-metrics-java/issues/66

*Description of changes:*
Changed the RootNode constructor so that the ObjectMapper is no longer instantiated on each new RootNode.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
