### PR TITLE
Split a metric when there're more than 100 data points

### DIFF
--- a/src/main/java/software/amazon/cloudwatchlogs/emf/Constants.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/Constants.java
@@ -22,4 +22,6 @@ public class Constants {
     public static final String UNKNOWN = "Unknown";
 
     public static final int MAX_METRICS_PER_EVENT = 100;
+
+    public static final int MAX_DATAPOINTS_PER_METRIC = 100;
 }

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/model/MetricsContext.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/model/MetricsContext.java
@@ -218,7 +218,7 @@ public class MetricsContext {
             Queue<MetricDefinition> metricDefinitions =
                     new LinkedList<>(rootNode.metrics().values());
             while (metricDefinitions.size() > 0) {
-                MetricDefinition metric = metricDefinitions.peek();
+                MetricDefinition metric = metricDefinitions.poll();
 
                 if (metrics.size() == Constants.MAX_METRICS_PER_EVENT
                         || metrics.containsKey(metric.getName())) {
@@ -226,7 +226,6 @@ public class MetricsContext {
                     metrics = new HashMap<>();
                 }
 
-                metric = metricDefinitions.poll();
                 if (metric.getValues().size() <= Constants.MAX_DATAPOINTS_PER_METRIC) {
                     metrics.put(metric.getName(), metric);
                 } else {


### PR DESCRIPTION
*Issue #, if available:*
[Metric Value List can go above MetricDefinition limits, causing CW missing metrics ](https://github.com/awslabs/aws-embedded-metrics-java/issues/72)


*Description of changes:*

Split a metric into multiple log events if the metric has more than 100 data points

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
