### PR TITLE
Fixed a bug of carrying default dimensions over flushes

### DIFF
--- a/src/main/java/software/amazon/cloudwatchlogs/emf/model/Metadata.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/model/Metadata.java
@@ -70,6 +70,11 @@ class Metadata {
         return newMetricDirective;
     }
 
+    void setMetricDirective(MetricDirective metricDirective) {
+        cloudWatchMetrics = new ArrayList<>();
+        cloudWatchMetrics.add(metricDirective);
+    }
+
     /**
      * Test if there's any metric added.
      *

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/model/MetricDirective.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/model/MetricDirective.java
@@ -115,4 +115,18 @@ class MetricDirective {
     boolean hasNoMetrics() {
         return this.getMetrics().isEmpty();
     }
+
+    /**
+     * Create a copy of the metric directive without having the existing metrics
+     *
+     * @return A object of metric directive
+     */
+    MetricDirective copyWithoutMetrics() {
+        MetricDirective metricDirective = new MetricDirective();
+        metricDirective.setDefaultDimensions(this.defaultDimensions);
+        metricDirective.setDimensions(this.dimensions);
+        metricDirective.setNamespace(this.namespace);
+        metricDirective.shouldUseDefaultDimension = this.shouldUseDefaultDimension;
+        return metricDirective;
+    }
 }

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/model/MetricsContext.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/model/MetricsContext.java
@@ -37,6 +37,12 @@ public class MetricsContext {
         metricDirective = rootNode.getAws().createMetricDirective();
     }
 
+    public MetricsContext(MetricDirective metricDirective) {
+        this();
+        this.rootNode.getAws().setMetricDirective(metricDirective);
+        this.metricDirective = metricDirective;
+    }
+
     public MetricsContext(
             String namespace,
             Map<String, Object> properties,
@@ -191,11 +197,7 @@ public class MetricsContext {
 
     /** @return Creates an independently flushable context. */
     public MetricsContext createCopyWithContext() {
-        return new MetricsContext(
-                this.metricDirective.getNamespace(),
-                this.rootNode.getProperties(),
-                this.metricDirective.getDimensions(),
-                this.metricDirective.getDefaultDimensions());
+        return new MetricsContext(metricDirective.copyWithoutMetrics());
     }
 
     /**

--- a/src/test/java/software/amazon/cloudwatchlogs/emf/logger/MetricsLoggerTest.java
+++ b/src/test/java/software/amazon/cloudwatchlogs/emf/logger/MetricsLoggerTest.java
@@ -225,7 +225,6 @@ public class MetricsLoggerTest {
         assertFalse(sink.getLogEvents().get(0).contains("Count"));
     }
 
-
     @Test
     public void testNoDimensionsAfterSetEmptyDimensionSet() {
         MetricsLogger logger = new MetricsLogger(envProvider);


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/aws-embedded-metrics-java/issues/37

*Description of changes:*
Fixed a bug that the default dimensions are carried over to new log event after calling `setDimension`

Before change, with the following code

```java
        MetricsLogger logger = new MetricsLogger(envProvider);

        logger.setDimensions();
        logger.putMetric("Counter", 1.0);
        logger.flush();

        logger.putMetric("Counter", 2.0);
        // second flush
        logger.flush();

```
There're still default dimensions included in the log event from second flush.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
