### PR TITLE
Set lombok to be a compileOnly dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,7 +59,7 @@ configurations {
 dependencies {
 	annotationProcessor 'org.projectlombok:lombok:1.18.12'
 
-	implementation 'org.projectlombok:lombok:1.18.12'
+	compileOnly 'org.projectlombok:lombok:1.18.12'
 	implementation 'com.fasterxml.jackson.core:jackson-core:2.11.1'
 	implementation 'com.fasterxml.jackson.core:jackson-annotations:2.11.1'
 	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.11.1'
@@ -75,6 +75,7 @@ dependencies {
 	testImplementation "com.github.javafaker:javafaker:1.0.2"
 	testImplementation "com.github.tomakehurst:wiremock-jre8:2.27.0"
 	testImplementation 'software.amazon.awssdk:cloudwatch:2.13.54'
+	testCompileOnly 'org.projectlombok:lombok:1.18.12'
 	testAnnotationProcessor 'org.projectlombok:lombok:1.18.12'
 }
 


### PR DESCRIPTION
*Issue #, if available:*
#76 

*Description of changes:*
Set lombok to be a compileOnly dependency, as it's not used in runtime.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
