### PR TITLE
Use ECR to download image for integration tests

### DIFF
--- a/src/integration-test/resources/agent/Dockerfile
+++ b/src/integration-test/resources/agent/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM debian:latest
+FROM public.ecr.aws/lts/ubuntu:latest
 
 RUN apt-get update &&  \
     apt-get install -y ca-certificates curl && \


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Changed DockerHub's image to ubuntu image from ECR Public Gallery to run integration tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
