### PR TITLE
Add asynchronous flush support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ build
 out
 .settings
 .temp
+bin

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ allprojects {
 		targetCompatibility = '1.8'
 	}
 
-	version = '1.0.4'
+	version = '2.0.0-beta-1'
 }
 
 java {
@@ -64,6 +64,7 @@ dependencies {
 	implementation 'com.fasterxml.jackson.core:jackson-annotations:2.11.1'
 	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.11.1'
 	implementation 'org.slf4j:slf4j-api:1.7.30'
+	implementation 'org.javatuples:javatuples:1.2'
 
 	// Use JUnit test framework
 	testImplementation 'software.amazon.awssdk:cloudwatch:2.13.54'

--- a/buildspecs/buildspec.canary.yml
+++ b/buildspecs/buildspec.canary.yml
@@ -9,7 +9,7 @@ env:
 phases:
   install:
     runtime-versions:
-      java: corretto8
+      java: corretto11
     commands:
       # start docker
       # https://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker-custom-image.html#sample-docker-custom-image-files

--- a/buildspecs/buildspec.release.yml
+++ b/buildspecs/buildspec.release.yml
@@ -11,7 +11,7 @@ env:
 phases:
   install:
     runtime-versions:
-      java: corretto8
+      java: corretto11
   build:
     commands:
       - ./gradlew publish

--- a/buildspecs/buildspec.yml
+++ b/buildspecs/buildspec.yml
@@ -9,7 +9,7 @@ env:
 phases:
   install:
     runtime-versions:
-      java: corretto8
+      java: corretto11
     commands:
       # start docker
       # https://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker-custom-image.html#sample-docker-custom-image-files

--- a/examples/agent/src/main/java/agent/App.java
+++ b/examples/agent/src/main/java/agent/App.java
@@ -1,14 +1,27 @@
 package agent;
 
+import software.amazon.cloudwatchlogs.emf.config.EnvironmentConfigurationProvider;
+import software.amazon.cloudwatchlogs.emf.environment.DefaultEnvironment;
+import software.amazon.cloudwatchlogs.emf.environment.Environment;
 import software.amazon.cloudwatchlogs.emf.logger.MetricsLogger;
 import software.amazon.cloudwatchlogs.emf.model.DimensionSet;
 import software.amazon.cloudwatchlogs.emf.model.Unit;
 
+import java.util.concurrent.TimeUnit;
+
 public class App {
 
     public static void main(String[] args) {
-        MetricsLogger logger = new MetricsLogger();
-        logger.putDimensions(DimensionSet.of("Operation", "Agent"));
+        DefaultEnvironment environment = new DefaultEnvironment(EnvironmentConfigurationProvider.getConfig());
+        emitMetric(environment);
+        emitMetric(environment);
+        emitMetric(environment);
+        environment.getSink().shutdown().orTimeout(360_000L, TimeUnit.MILLISECONDS);
+    }
+
+    private static void emitMetric(Environment environment) {
+        MetricsLogger logger = new MetricsLogger(environment);
+        logger.setDimensions(DimensionSet.of("Operation", "Agent"));
         logger.putMetric("ExampleMetric", 100, Unit.MILLISECONDS);
         logger.putProperty("RequestId", "422b1569-16f6-4a03-b8f0-fe3fd9b100f8");
         logger.flush();

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/Constants.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/Constants.java
@@ -24,4 +24,27 @@ public class Constants {
     public static final int MAX_METRICS_PER_EVENT = 100;
 
     public static final int MAX_DATAPOINTS_PER_METRIC = 100;
+
+    /**
+     * The max number of messages to hold in memory in case of transient socket errors. The maximum
+     * message size is 256 KB meaning the maximum size of this buffer would be 25,600 MB
+     */
+    public static final int DEFAULT_ASYNC_BUFFER_SIZE = 100;
+
+    /**
+     * How many times to retry an individual message. We eventually give up vs. retrying
+     * indefinitely in case there is something inherent to the message that is causing the failures.
+     * Giving up results in data loss, but also helps us reduce the risk of a poison pill blocking
+     * all process telemetry.
+     */
+    public static final int MAX_ATTEMPTS_PER_MESSAGE = 100;
+
+    /** Starting backoff millis when a transient socket failure is encountered. */
+    public static final int MIN_BACKOFF_MILLIS = 50;
+
+    /** Max backoff millis when a transient socket failure is encountered. */
+    public static final int MAX_BACKOFF_MILLIS = 2000;
+
+    /** Maximum amount of random jitter to apply to retries */
+    public static final int MAX_BACKOFF_JITTER = 20;
 }

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/config/Configuration.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/config/Configuration.java
@@ -18,8 +18,10 @@ package software.amazon.cloudwatchlogs.emf.config;
 
 import java.util.Optional;
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import software.amazon.cloudwatchlogs.emf.Constants;
 import software.amazon.cloudwatchlogs.emf.environment.Environments;
 import software.amazon.cloudwatchlogs.emf.util.StringUtils;
 
@@ -54,6 +56,9 @@ public class Configuration {
      */
     @Setter Environments environmentOverride;
 
+    /** Queue length for asynchronous sinks. */
+    @Setter @Getter int asyncBufferSize = Constants.DEFAULT_ASYNC_BUFFER_SIZE;
+
     public Optional<String> getServiceName() {
         return getStringOptional(serviceName);
     }
@@ -85,6 +90,6 @@ public class Configuration {
         if (StringUtils.isNullOrEmpty(value)) {
             return Optional.empty();
         }
-        return Optional.ofNullable(value);
+        return Optional.of(value);
     }
 }

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/config/ConfigurationKeys.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/config/ConfigurationKeys.java
@@ -27,4 +27,5 @@ public class ConfigurationKeys {
     public static final String LOG_STREAM_NAME = "LOG_STREAM_NAME";
     public static final String AGENT_ENDPOINT = "AGENT_ENDPOINT";
     public static final String ENVIRONMENT_OVERRIDE = "ENVIRONMENT";
+    public static final String ASYNC_BUFFER_SIZE = "ASYNC_BUFFER_SIZE";
 }

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/environment/AgentBasedEnvironment.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/environment/AgentBasedEnvironment.java
@@ -23,10 +23,11 @@ import software.amazon.cloudwatchlogs.emf.sinks.AgentSink;
 import software.amazon.cloudwatchlogs.emf.sinks.Endpoint;
 import software.amazon.cloudwatchlogs.emf.sinks.ISink;
 import software.amazon.cloudwatchlogs.emf.sinks.SocketClientFactory;
+import software.amazon.cloudwatchlogs.emf.sinks.retry.FibonacciRetryStrategy;
 
 @Slf4j
 public abstract class AgentBasedEnvironment implements Environment {
-    private Configuration config;
+    private final Configuration config;
     private ISink sink;
 
     public AgentBasedEnvironment(Configuration config) {
@@ -68,7 +69,13 @@ public abstract class AgentBasedEnvironment implements Environment {
                             getLogGroupName(),
                             getLogStreamName(),
                             endpoint,
-                            new SocketClientFactory());
+                            new SocketClientFactory(),
+                            config.getAsyncBufferSize(),
+                            () ->
+                                    new FibonacciRetryStrategy(
+                                            Constants.MIN_BACKOFF_MILLIS,
+                                            Constants.MAX_BACKOFF_MILLIS,
+                                            Constants.MAX_BACKOFF_JITTER));
         }
         return sink;
     }

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/environment/DefaultEnvironment.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/environment/DefaultEnvironment.java
@@ -22,10 +22,10 @@ import software.amazon.cloudwatchlogs.emf.config.Configuration;
 import software.amazon.cloudwatchlogs.emf.model.MetricsContext;
 
 @Slf4j
-class DefaultEnvironment extends AgentBasedEnvironment {
+public class DefaultEnvironment extends AgentBasedEnvironment {
     private Configuration config;
 
-    DefaultEnvironment(Configuration config) {
+    public DefaultEnvironment(Configuration config) {
         super(config);
         this.config = config;
     }

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/environment/EC2Environment.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/environment/EC2Environment.java
@@ -26,7 +26,7 @@ import software.amazon.cloudwatchlogs.emf.exception.EMFClientException;
 import software.amazon.cloudwatchlogs.emf.model.MetricsContext;
 
 @Slf4j
-class EC2Environment extends AgentBasedEnvironment {
+public class EC2Environment extends AgentBasedEnvironment {
     private Configuration config;
     private EC2Metadata metadata;
     private ResourceFetcher fetcher;

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/environment/ECSEnvironment.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/environment/ECSEnvironment.java
@@ -32,7 +32,7 @@ import software.amazon.cloudwatchlogs.emf.model.MetricsContext;
 import software.amazon.cloudwatchlogs.emf.util.StringUtils;
 
 @Slf4j
-class ECSEnvironment extends AgentBasedEnvironment {
+public class ECSEnvironment extends AgentBasedEnvironment {
     private Configuration config;
     private ECSMetadata metadata;
     private ResourceFetcher fetcher;
@@ -42,6 +42,10 @@ class ECSEnvironment extends AgentBasedEnvironment {
     private static final String ECS_CONTAINER_METADATA_URI = "ECS_CONTAINER_METADATA_URI";
     private static final String FLUENT_HOST = "FLUENT_HOST";
     private static final String ENVIRONMENT_TYPE = "AWS::ECS::Container";
+
+    public ECSEnvironment(Configuration config) {
+        this(config, new ResourceFetcher());
+    }
 
     ECSEnvironment(Configuration config, ResourceFetcher fetcher) {
         super(config);

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/environment/LambdaEnvironment.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/environment/LambdaEnvironment.java
@@ -23,7 +23,7 @@ import software.amazon.cloudwatchlogs.emf.sinks.ConsoleSink;
 import software.amazon.cloudwatchlogs.emf.sinks.ISink;
 
 /** An environment stands for the AWS Lambda environment. */
-class LambdaEnvironment implements Environment {
+public class LambdaEnvironment implements Environment {
     private static final String AWS_EXECUTION_ENV = "AWS_EXECUTION_ENV";
     private static final String LAMBDA_FUNCTION_NAME = "AWS_LAMBDA_FUNCTION_NAME";
     private static final String LAMBDA_FUNCTION_VERSION = "AWS_LAMBDA_FUNCTION_VERSION";

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/environment/LocalEnvironment.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/environment/LocalEnvironment.java
@@ -24,7 +24,7 @@ import software.amazon.cloudwatchlogs.emf.sinks.ConsoleSink;
 import software.amazon.cloudwatchlogs.emf.sinks.ISink;
 
 @Slf4j
-class LocalEnvironment implements Environment {
+public class LocalEnvironment implements Environment {
     private ISink sink;
     private Configuration config;
 

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/environment/ResourceFetcher.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/environment/ResourceFetcher.java
@@ -29,7 +29,7 @@ import software.amazon.cloudwatchlogs.emf.util.IOUtils;
 import software.amazon.cloudwatchlogs.emf.util.Jackson;
 
 @Slf4j
-class ResourceFetcher {
+public class ResourceFetcher {
 
     /** Fetch a json object from a given uri and deserialize it to the specified class: clazz. */
     <T> T fetch(URI endpoint, Class<T> clazz) {

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/logger/MetricsLogger.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/logger/MetricsLogger.java
@@ -40,6 +40,12 @@ public class MetricsLogger {
         this(new EnvironmentProvider());
     }
 
+    public MetricsLogger(Environment environment) {
+        context = new MetricsContext();
+        environmentFuture = CompletableFuture.completedFuture(environment);
+        environmentProvider = null; // TODO: should do some refactoring here
+    }
+
     public MetricsLogger(EnvironmentProvider environmentProvider) {
         this(environmentProvider, new MetricsContext());
     }

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/sinks/AgentSink.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/sinks/AgentSink.java
@@ -17,28 +17,61 @@
 package software.amazon.cloudwatchlogs.emf.sinks;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import software.amazon.cloudwatchlogs.emf.Constants;
+import software.amazon.cloudwatchlogs.emf.exception.EMFClientException;
 import software.amazon.cloudwatchlogs.emf.model.MetricsContext;
+import software.amazon.cloudwatchlogs.emf.sinks.retry.RetryStrategy;
 import software.amazon.cloudwatchlogs.emf.util.StringUtils;
 
-/** An sink connecting to CloudWatch Agent. */
+/** An sink connecting to an agent over a socket. */
 @Slf4j
 public class AgentSink implements ISink {
     private final String logGroupName;
     private final String logStreamName;
     private final SocketClient client;
+    private final ExecutorService executor;
+    private final Supplier<RetryStrategy> retryStrategyFactory;
+    private final LinkedBlockingQueue<Runnable> queue;
 
     public AgentSink(
             String logGroupName,
             String logStreamName,
             Endpoint endpoint,
-            SocketClientFactory clientFactory) {
+            SocketClientFactory clientFactory,
+            int asyncQueueDepth,
+            Supplier<RetryStrategy> retryStrategy) {
         this.logGroupName = logGroupName;
         this.logStreamName = logStreamName;
         client = clientFactory.getClient(endpoint);
+        queue = new LinkedBlockingQueue<>(asyncQueueDepth);
+        executor = createSingleThreadedExecutor();
+        this.retryStrategyFactory = retryStrategy;
+    }
+
+    private ExecutorService createSingleThreadedExecutor() {
+        return new ThreadPoolExecutor(
+                1,
+                1,
+                0L,
+                TimeUnit.MILLISECONDS,
+                queue,
+                new ThreadPoolExecutor.DiscardOldestPolicy());
     }
 
     public void accept(MetricsContext context) {
+        if (executor.isShutdown()) {
+            throw new EMFClientException(
+                    "Attempted to write data to a sink that has been previously shutdown.");
+        }
+
         if (!StringUtils.isNullOrEmpty(logGroupName)) {
             context.putMetadata("LogGroupName", logGroupName);
         }
@@ -49,10 +82,65 @@ public class AgentSink implements ISink {
 
         try {
             for (String event : context.serialize()) {
-                client.sendMessage(event + "\n");
+                executor.submit(new Sender(event, client, retryStrategyFactory));
             }
         } catch (JsonProcessingException e) {
             log.error("Failed to serialize the metrics with the exception: ", e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<Void> shutdown() {
+        executor.shutdown();
+        return CompletableFuture.supplyAsync(
+                () -> {
+                    try {
+                        while ((!executor.awaitTermination(1000, TimeUnit.MILLISECONDS))) {
+                            // we add 1 because we assume that at least one task is running if the
+                            // queue is blocked
+                            log.debug(
+                                    "Waiting for graceful shutdown to complete. {} tasks pending.",
+                                    queue.size() + 1);
+                        }
+                    } catch (InterruptedException e) {
+                        log.warn("Thread terminated while awaiting shutdown.");
+                    }
+                    return null;
+                });
+    }
+
+    @AllArgsConstructor
+    private static class Sender implements Runnable {
+        private final String event;
+        private final SocketClient client;
+        private final Supplier<RetryStrategy> retryStrategyFactory;
+
+        @Override
+        public void run() {
+            if (!StringUtils.isNullOrEmpty(event)) {
+                try {
+                    sendMessageForMaxAttempts();
+                } catch (InterruptedException e) {
+                    log.warn("Thread was interrupted while sending EMF event.");
+                }
+            }
+        }
+
+        private void sendMessageForMaxAttempts() throws InterruptedException {
+            RetryStrategy backoff = null;
+
+            for (int i = 0; i < Constants.MAX_ATTEMPTS_PER_MESSAGE; i++) {
+                try {
+                    client.sendMessage(event + "\n");
+                    return;
+                } catch (Exception e) {
+                    log.debug(
+                            "Failed to write the message to the socket. Backing off and trying again.",
+                            e);
+                    backoff = backoff != null ? backoff : retryStrategyFactory.get();
+                    Thread.sleep(backoff.next());
+                }
+            }
         }
     }
 }

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/sinks/ConsoleSink.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/sinks/ConsoleSink.java
@@ -17,6 +17,7 @@
 package software.amazon.cloudwatchlogs.emf.sinks;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import java.util.concurrent.CompletableFuture;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -40,5 +41,10 @@ public class ConsoleSink implements ISink {
         } catch (JsonProcessingException e) {
             log.error("Failed to serialize a MetricsContext: ", e);
         }
+    }
+
+    @Override
+    public CompletableFuture<Void> shutdown() {
+        return CompletableFuture.completedFuture(null);
     }
 }

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/sinks/ISink.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/sinks/ISink.java
@@ -16,6 +16,7 @@
 
 package software.amazon.cloudwatchlogs.emf.sinks;
 
+import java.util.concurrent.CompletableFuture;
 import software.amazon.cloudwatchlogs.emf.model.MetricsContext;
 
 /** Interface for sinking log items to CloudWatch. */
@@ -27,4 +28,14 @@ public interface ISink {
      * @param context MetricsContext
      */
     void accept(MetricsContext context);
+
+    /**
+     * Shutdown the sink. The returned {@link CompletableFuture} will be completed when all queued
+     * events have been flushed. After this is called, no more metrics can be sent through this sink
+     * and attempting to continue to re-use the sink will result in undefined behavior.
+     *
+     * @return a future that completes when the shutdown has completed successfully and all pending
+     *     messages have been sent to the destination.
+     */
+    CompletableFuture<Void> shutdown();
 }

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/sinks/retry/FibonacciRetryStrategy.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/sinks/retry/FibonacciRetryStrategy.java
@@ -1,0 +1,32 @@
+package software.amazon.cloudwatchlogs.emf.sinks.retry;
+
+import java.util.concurrent.ThreadLocalRandom;
+import org.javatuples.Pair;
+
+/**
+ * A Fibonacci sequence with an upper bound. Once the upper limit is hit, all subsequent calls to
+ * `next()` will return the provided limit.
+ */
+public class FibonacciRetryStrategy implements RetryStrategy {
+    private final int maxJitter;
+    private final int upperBound;
+
+    Pair<Integer, Integer> cursor;
+
+    public FibonacciRetryStrategy(int start, int upperBound, int maxJitter) {
+        cursor = new Pair<>(start, start);
+        this.upperBound = upperBound;
+        this.maxJitter = maxJitter;
+    }
+
+    public int next() {
+        int nextValue = cursor.getValue0() + cursor.getValue1();
+        if (cursor.getValue1() >= upperBound) {
+            cursor = new Pair<>(upperBound, upperBound);
+        } else {
+            cursor = new Pair<>(cursor.getValue1(), nextValue);
+        }
+        int jitter = maxJitter > 0 ? ThreadLocalRandom.current().nextInt(maxJitter) : 0;
+        return cursor.getValue0() + jitter;
+    }
+}

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/sinks/retry/RetryStrategy.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/sinks/retry/RetryStrategy.java
@@ -1,0 +1,10 @@
+package software.amazon.cloudwatchlogs.emf.sinks.retry;
+
+public interface RetryStrategy {
+    /**
+     * Gets the amount of time to wait in millis before retrying
+     *
+     * @return millis to wait before retrying
+     */
+    int next();
+}

--- a/src/test/java/software/amazon/cloudwatchlogs/emf/config/ConfigurationTest.java
+++ b/src/test/java/software/amazon/cloudwatchlogs/emf/config/ConfigurationTest.java
@@ -35,7 +35,7 @@ public class ConfigurationTest {
     }
 
     @Test
-    public void testReturnEmptyIfNotSet() {
+    public void testReturnEmptyOrDefaultIfNotSet() {
         assertFalse(config.getAgentEndpoint().isPresent());
         assertFalse(config.getLogGroupName().isPresent());
         assertFalse(config.getLogStreamName().isPresent());
@@ -43,6 +43,7 @@ public class ConfigurationTest {
         assertFalse(config.getServiceName().isPresent());
 
         assertEquals(config.getEnvironmentOverride(), Environments.Unknown);
+        assertEquals(config.getAsyncBufferSize(), 100);
     }
 
     @Test
@@ -70,12 +71,15 @@ public class ConfigurationTest {
         String expectedServiceType = faker.letterify("????");
         String expectedServiceName = faker.letterify("????");
         Environments expectedEnvironment = Environments.Agent;
+        int expectedAsyncBufferSize = faker.number().randomDigit();
+
         config.setAgentEndpoint(expectedEndpoint);
         config.setLogGroupName(expectedLogGroupName);
         config.setLogStreamName(expectedLogStreamName);
         config.setServiceType(expectedServiceType);
         config.setServiceName(expectedServiceName);
         config.setEnvironmentOverride(expectedEnvironment);
+        config.setAsyncBufferSize(expectedAsyncBufferSize);
 
         assertEquals(config.getAgentEndpoint().get(), expectedEndpoint);
         assertEquals(config.getLogGroupName().get(), expectedLogGroupName);
@@ -83,5 +87,6 @@ public class ConfigurationTest {
         assertEquals(config.getServiceType().get(), expectedServiceType);
         assertEquals(config.getServiceName().get(), expectedServiceName);
         assertEquals(config.getEnvironmentOverride(), expectedEnvironment);
+        assertEquals(config.getAsyncBufferSize(), expectedAsyncBufferSize);
     }
 }

--- a/src/test/java/software/amazon/cloudwatchlogs/emf/config/EnvironmentConfigurationProviderTest.java
+++ b/src/test/java/software/amazon/cloudwatchlogs/emf/config/EnvironmentConfigurationProviderTest.java
@@ -18,7 +18,6 @@ package software.amazon.cloudwatchlogs.emf.config;
 
 import static org.junit.Assert.*;
 
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.api.mockito.PowerMockito;
@@ -40,14 +39,30 @@ public class EnvironmentConfigurationProviderTest {
         putEnv("AWS_EMF_LOG_STREAM_NAME", "TestLogStream");
         putEnv("AWS_EMF_AGENT_ENDPOINT", "Endpoint");
         putEnv("AWS_EMF_ENVIRONMENT", "Agent");
-        Configuration config = EnvironmentConfigurationProvider.getConfig();
+        putEnv("AWS_EMF_ASYNC_BUFFER_SIZE", "9999");
+
+        Configuration config = EnvironmentConfigurationProvider.createConfig();
 
         assertEquals(config.getServiceName().get(), "TestServiceName");
         assertEquals(config.getServiceType().get(), "TestServiceType");
         assertEquals(config.getLogGroupName().get(), "TestLogGroup");
         assertEquals(config.getLogStreamName().get(), "TestLogStream");
         assertEquals(config.getAgentEndpoint().get(), "Endpoint");
-        Assert.assertEquals(config.getEnvironmentOverride(), Environments.Agent);
+        assertEquals(config.getEnvironmentOverride(), Environments.Agent);
+        assertEquals(config.getAsyncBufferSize(), 9999);
+    }
+
+    @Test
+    public void invalidEnvironmentValuesFallbackToExpectedDefaults() {
+        // arrange
+        PowerMockito.mockStatic(SystemWrapper.class);
+
+        // act
+        putEnv("AWS_EMF_ASYNC_BUFFER_SIZE", "NaN");
+
+        // assert
+        Configuration config = EnvironmentConfigurationProvider.createConfig();
+        assertEquals(100, config.getAsyncBufferSize());
     }
 
     private void putEnv(String key, String value) {

--- a/src/test/java/software/amazon/cloudwatchlogs/emf/sinks/AgentSinkTest.java
+++ b/src/test/java/software/amazon/cloudwatchlogs/emf/sinks/AgentSinkTest.java
@@ -17,6 +17,7 @@
 package software.amazon.cloudwatchlogs.emf.sinks;
 
 import static junit.framework.TestCase.*;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -24,44 +25,22 @@ import static org.mockito.Mockito.when;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.ArrayList;
 import java.util.Map;
-import org.junit.Before;
+import java.util.concurrent.locks.ReentrantLock;
 import org.junit.Test;
+import software.amazon.cloudwatchlogs.emf.Constants;
+import software.amazon.cloudwatchlogs.emf.exception.EMFClientException;
 import software.amazon.cloudwatchlogs.emf.model.MetricsContext;
+import software.amazon.cloudwatchlogs.emf.sinks.retry.RetryStrategy;
 
 @SuppressWarnings("unchecked")
 public class AgentSinkTest {
 
-    private SocketClientFactory factory;
-    private TestClient client;
-
-    class TestClient implements SocketClient {
-
-        private String message;
-
-        @Override
-        public void sendMessage(String message) {
-            this.message = message;
-        }
-
-        public String getMessage() {
-            return this.message;
-        }
-
-        @Override
-        public void close() {}
-    }
-
-    @Before
-    public void setUp() {
-        factory = mock(SocketClientFactory.class);
-
-        client = new TestClient();
-        when(factory.getClient(any())).thenReturn(client);
-    }
-
     @Test
     public void testAccept() throws JsonProcessingException {
+        // arrange
+        Fixture fixture = new Fixture();
         String prop = "TestProp";
         String propValue = "TestPropValue";
         String logGroupName = "TestLogGroup";
@@ -73,14 +52,24 @@ public class AgentSinkTest {
         mc.putMetric("Time", 10);
 
         AgentSink sink =
-                new AgentSink(logGroupName, logStreamName, Endpoint.DEFAULT_TCP_ENDPOINT, factory);
+                new AgentSink(
+                        logGroupName,
+                        logStreamName,
+                        Endpoint.DEFAULT_TCP_ENDPOINT,
+                        fixture.factory,
+                        1,
+                        InstantRetryStrategy::new);
 
+        // act
         sink.accept(mc);
+        sink.shutdown().join();
 
+        // assert
         ObjectMapper objectMapper = new ObjectMapper();
         Map<String, Object> emf_map =
                 objectMapper.readValue(
-                        client.getMessage(), new TypeReference<Map<String, Object>>() {});
+                        fixture.client.getMessages().get(0),
+                        new TypeReference<Map<String, Object>>() {});
         Map<String, Object> metadata = (Map<String, Object>) emf_map.get("_aws");
 
         assertEquals(emf_map.get(prop), propValue);
@@ -91,19 +80,251 @@ public class AgentSinkTest {
 
     @Test
     public void testEmptyLogGroupName() throws JsonProcessingException {
+        // arrange
+        Fixture fixture = new Fixture();
         String logGroupName = "";
-        AgentSink sink = new AgentSink(logGroupName, null, Endpoint.DEFAULT_TCP_ENDPOINT, factory);
+        AgentSink sink =
+                new AgentSink(
+                        logGroupName,
+                        null,
+                        Endpoint.DEFAULT_TCP_ENDPOINT,
+                        fixture.factory,
+                        1,
+                        InstantRetryStrategy::new);
         MetricsContext mc = new MetricsContext();
         mc.putMetric("Time", 10);
 
+        // act
         sink.accept(mc);
+        sink.shutdown().join();
+
+        // assert
         ObjectMapper objectMapper = new ObjectMapper();
         Map<String, Object> emf_map =
                 objectMapper.readValue(
-                        client.getMessage(), new TypeReference<Map<String, Object>>() {});
+                        fixture.client.getMessages().get(0), new TypeReference<>() {});
         Map<String, Object> metadata = (Map<String, Object>) emf_map.get("_aws");
 
         assertFalse(metadata.containsKey("LogGroupName"));
         assertFalse(metadata.containsKey("LogStreamName"));
+    }
+
+    @Test
+    public void testFailuresAreRetried() {
+        // arrange
+        Fixture fixture = new Fixture();
+        fixture.client.messagesToFail = Constants.MAX_ATTEMPTS_PER_MESSAGE - 1;
+        AgentSink sink =
+                new AgentSink(
+                        "",
+                        null,
+                        Endpoint.DEFAULT_TCP_ENDPOINT,
+                        fixture.factory,
+                        1,
+                        InstantRetryStrategy::new);
+
+        MetricsContext mc = new MetricsContext();
+        mc.putMetric("Time", 10);
+
+        // act
+        sink.accept(mc);
+        sink.shutdown().join();
+
+        // assert
+        assertEquals(Constants.MAX_ATTEMPTS_PER_MESSAGE - 1, fixture.client.messagesFailed);
+        assertEquals(1, fixture.client.messagesSent);
+    }
+
+    @Test
+    public void testFailuresAreRetriedWithMaximumLimit() {
+        // arrange
+        Fixture fixture = new Fixture();
+        fixture.client.messagesToFail = Constants.MAX_ATTEMPTS_PER_MESSAGE + 1;
+        AgentSink sink =
+                new AgentSink(
+                        "",
+                        null,
+                        Endpoint.DEFAULT_TCP_ENDPOINT,
+                        fixture.factory,
+                        1,
+                        InstantRetryStrategy::new);
+
+        MetricsContext mc = new MetricsContext();
+        mc.putMetric("Time", 10);
+
+        // act
+        sink.accept(mc);
+        sink.shutdown().join();
+
+        // assert
+        assertEquals(Constants.MAX_ATTEMPTS_PER_MESSAGE, fixture.client.messagesFailed);
+        assertEquals(0, fixture.client.messagesSent);
+    }
+
+    @Test
+    public void failedMessagesAreQueued() {
+        // arrange
+        Fixture fixture = new Fixture();
+        fixture.client.messagesToFail = Constants.MAX_ATTEMPTS_PER_MESSAGE * 2;
+        AgentSink sink =
+                new AgentSink(
+                        "",
+                        null,
+                        Endpoint.DEFAULT_TCP_ENDPOINT,
+                        fixture.factory,
+                        1,
+                        InstantRetryStrategy::new);
+
+        MetricsContext mc = new MetricsContext();
+        mc.putMetric("Time", 10);
+
+        // act
+        sink.accept(mc);
+        sink.accept(mc);
+
+        sink.shutdown().join();
+
+        // assert
+        assertEquals(Constants.MAX_ATTEMPTS_PER_MESSAGE * 2, fixture.client.messagesFailed);
+        assertEquals(0, fixture.client.messagesSent);
+    }
+
+    @Test
+    public void queuedMessagesAreBounded() {
+        // arrange
+        Fixture fixture = new Fixture();
+        fixture.client.messagesToFail = Constants.MAX_ATTEMPTS_PER_MESSAGE * 3;
+        AgentSink sink =
+                new AgentSink(
+                        "",
+                        null,
+                        Endpoint.DEFAULT_TCP_ENDPOINT,
+                        fixture.factory,
+                        2,
+                        InstantRetryStrategy::new);
+
+        MetricsContext mc = new MetricsContext();
+        mc.putMetric("Time", 10);
+
+        // act
+        sink.accept(mc);
+        sink.accept(mc);
+
+        sink.shutdown().join();
+
+        // assert
+        assertEquals(Constants.MAX_ATTEMPTS_PER_MESSAGE * 2, fixture.client.messagesFailed);
+        assertEquals(0, fixture.client.messagesSent);
+    }
+
+    @Test
+    public void oldestMessagesAreDropped() {
+        // arrange
+        Fixture fixture = new Fixture();
+        AgentSink sink =
+                new AgentSink(
+                        "",
+                        null,
+                        Endpoint.DEFAULT_TCP_ENDPOINT,
+                        fixture.factory,
+                        1,
+                        InstantRetryStrategy::new);
+
+        // prevent any message from being sent by the client yet
+        fixture.client.lock.lock();
+
+        // two different payloads
+        // we'll fill the queue with the first one and then insert the second
+        MetricsContext send = new MetricsContext();
+        send.putMetric("SEND", 10);
+
+        MetricsContext shouldDrop = new MetricsContext();
+        shouldDrop.putMetric("DROP", 10);
+
+        // act
+        sink.accept(send);
+        sink.accept(
+                shouldDrop); // this goes in second because the first message will be pulled off the
+        // queue immediately
+        sink.accept(send); // this one should overwrite the previous message
+        fixture.client.lock.unlock();
+        sink.shutdown().join();
+
+        // assert
+        assertEquals(0, fixture.client.messagesFailed);
+        assertEquals(2, fixture.client.messagesSent);
+        fixture.client.messages.forEach(message -> assertFalse(message.contains("DONT_SEND")));
+    }
+
+    @Test
+    public void cannotEnqueueDataAfterShuttingDownSink() {
+        // arrange
+        Fixture fixture = new Fixture();
+        AgentSink sink =
+                new AgentSink(
+                        "",
+                        null,
+                        Endpoint.DEFAULT_TCP_ENDPOINT,
+                        fixture.factory,
+                        1,
+                        InstantRetryStrategy::new);
+
+        // act
+        sink.shutdown();
+
+        // assert
+        assertThrows(EMFClientException.class, () -> sink.accept(new MetricsContext()));
+    }
+
+    class Fixture {
+        SocketClientFactory factory;
+        TestClient client;
+
+        Fixture() {
+            factory = mock(SocketClientFactory.class);
+            client = new TestClient();
+            when(factory.getClient(any())).thenReturn(client);
+        }
+    }
+
+    class TestClient implements SocketClient {
+
+        private final ArrayList<String> messages = new ArrayList<>();
+
+        // use this lock to control concurrency and block writing / retires
+        // to the socket
+        private final ReentrantLock lock = new ReentrantLock();
+
+        private int messagesSent = 0;
+        private int messagesFailed = 0;
+        private int messagesToFail = 0;
+
+        @Override
+        public void sendMessage(String message) {
+            if (messagesToFail > messagesFailed) {
+                messagesFailed++;
+                throw new RuntimeException("Failed to send message");
+            } else {
+                messagesSent++;
+                lock.lock();
+                this.messages.add(message);
+                lock.unlock();
+            }
+        }
+
+        public ArrayList<String> getMessages() {
+            return this.messages;
+        }
+
+        @Override
+        public void close() {}
+    }
+
+    class InstantRetryStrategy implements RetryStrategy {
+
+        @Override
+        public int next() {
+            return 0;
+        }
     }
 }

--- a/src/test/java/software/amazon/cloudwatchlogs/emf/sinks/MultiSinkTest.java
+++ b/src/test/java/software/amazon/cloudwatchlogs/emf/sinks/MultiSinkTest.java
@@ -1,0 +1,68 @@
+package software.amazon.cloudwatchlogs.emf.sinks;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.concurrent.CompletableFuture;
+import lombok.Getter;
+import org.junit.Test;
+import software.amazon.cloudwatchlogs.emf.model.MetricsContext;
+
+public class MultiSinkTest {
+    @Test
+    public void shutdownClosesAllComponentSinks() {
+        // arrange
+        TestSink sink1 = new TestSink();
+        TestSink sink2 = new TestSink();
+        MultiSink multiSink = MultiSink.builder().sink(sink1).sink(sink2).build();
+
+        // act
+        CompletableFuture<Void> future = multiSink.shutdown();
+
+        // assert
+        assertTrue(future.isDone());
+        assertEquals(1, sink1.getShutdowns());
+        assertEquals(1, sink2.getShutdowns());
+    }
+
+    @Test
+    public void shutdownCompletesExceptionallyIfComponentSinkCompletesExceptionally() {
+        // arrange
+        CompletableFuture<Void> failedResult =
+                CompletableFuture.failedFuture(new RuntimeException());
+        TestSink sink1 = new TestSink();
+        TestSink sink2 = new TestSink(failedResult);
+        MultiSink multiSink = MultiSink.builder().sink(sink1).sink(sink2).build();
+
+        // act
+        CompletableFuture<Void> future = multiSink.shutdown();
+
+        // assert
+        assertTrue(future.isDone());
+        assertTrue(future.isCompletedExceptionally());
+        assertEquals(1, sink1.getShutdowns());
+        assertEquals(1, sink2.getShutdowns());
+    }
+
+    private static class TestSink implements ISink {
+        private final CompletableFuture<Void> shutdownResult;
+        @Getter int shutdowns = 0;
+
+        TestSink() {
+            this.shutdownResult = CompletableFuture.completedFuture(null);
+        }
+
+        TestSink(CompletableFuture<Void> shutdownResult) {
+            this.shutdownResult = shutdownResult;
+        }
+
+        @Override
+        public void accept(MetricsContext context) {}
+
+        @Override
+        public CompletableFuture<Void> shutdown() {
+            shutdowns += 1;
+            return shutdownResult;
+        }
+    }
+}

--- a/src/test/java/software/amazon/cloudwatchlogs/emf/sinks/SinkShunt.java
+++ b/src/test/java/software/amazon/cloudwatchlogs/emf/sinks/SinkShunt.java
@@ -17,6 +17,7 @@
 package software.amazon.cloudwatchlogs.emf.sinks;
 
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import software.amazon.cloudwatchlogs.emf.model.MetricsContext;
 
 public class SinkShunt implements ISink {
@@ -33,6 +34,11 @@ public class SinkShunt implements ISink {
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
+    }
+
+    @Override
+    public CompletableFuture<Void> shutdown() {
+        return CompletableFuture.completedFuture(null);
     }
 
     public MetricsContext getContext() {

--- a/src/test/java/software/amazon/cloudwatchlogs/emf/sinks/retry/FibonacciRetryStrategyTest.java
+++ b/src/test/java/software/amazon/cloudwatchlogs/emf/sinks/retry/FibonacciRetryStrategyTest.java
@@ -1,0 +1,37 @@
+package software.amazon.cloudwatchlogs.emf.sinks.retry;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Test;
+import software.amazon.cloudwatchlogs.emf.Constants;
+
+public class FibonacciRetryStrategyTest {
+    @Test
+    public void testDefaultRetryMatchesExpectedSequence() {
+        // arrange
+        int start = Constants.MIN_BACKOFF_MILLIS;
+        int max = Constants.MAX_BACKOFF_MILLIS;
+        FibonacciRetryStrategy strategy = new FibonacciRetryStrategy(start, max, 0);
+
+        List<Integer> expectedSequence =
+                Arrays.asList(50, 100, 150, 250, 400, 650, 1050, 1700, 2000);
+        List<Integer> actualSequence = new ArrayList<>();
+
+        // act
+        int last = start;
+        while (last < max) {
+            last = strategy.next();
+            actualSequence.add(last);
+        }
+
+        // assert
+        assertEquals(expectedSequence, actualSequence);
+
+        // verify subsequent calls don't exceed max bounds
+        assertEquals(Constants.MAX_BACKOFF_MILLIS, strategy.next());
+        assertEquals(Constants.MAX_BACKOFF_MILLIS, strategy.next());
+    }
+}


### PR DESCRIPTION
Adds asynchronous flushing, automatic retries for transient socket errors, and graceful shutdown.

Design Notes / Other Considerations:

- I considered abstracting the asynchronous bits out into a separate type or into an abstract base class. However, the flush operation and error handling is currently tightly coupled to the TCP / UDP clients and there didn't seem to be much value in creating an abstraction just yet which is why I built it directly into the `AgentSink`.
- The shutdown interface returns a `CompletableFuture`. An alternative to this is providing an `(long timeout, TimeUnit unit)` signature similar to `awaitTermination` which would allow us to use that interface directly when shutting down the executor. However, this creates an awkward API that doesn't easily support composition with other tasks to run in parallel.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
