### PR TITLE
Migrate from IMDSv1 to IMDSv2

### DIFF
--- a/src/main/java/software/amazon/cloudwatchlogs/emf/environment/EC2Environment.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/environment/EC2Environment.java
@@ -18,8 +18,10 @@ package software.amazon.cloudwatchlogs.emf.environment;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.net.URI;
+import java.util.Collections;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
+import org.javatuples.Pair;
 import software.amazon.cloudwatchlogs.emf.Constants;
 import software.amazon.cloudwatchlogs.emf.config.Configuration;
 import software.amazon.cloudwatchlogs.emf.exception.EMFClientException;
@@ -33,7 +35,13 @@ public class EC2Environment extends AgentBasedEnvironment {
 
     private static final String INSTANCE_IDENTITY_URL =
             "http://169.254.169.254/latest/dynamic/instance-identity/document";
+
+    private static final String INSTANCE_TOKEN_URL = "http://169.254.169.254/latest/api/token";
     private static final String CFN_EC2_TYPE = "AWS::EC2::Instance";
+    private static final String TOKEN_REQUEST_HEADER_KEY = "X-aws-ec2-metadata-token-ttl-seconds";
+    private static final String TOKEN_REQUEST_HEADER_VALUE = "21600";
+
+    private static final String METADATA_REQUEST_TOKEN_HEADER_KEY = "X-aws-ec2-metadata-token";
 
     EC2Environment(Configuration config, ResourceFetcher fetcher) {
         super(config);
@@ -43,6 +51,28 @@ public class EC2Environment extends AgentBasedEnvironment {
 
     @Override
     public boolean probe() {
+        String token;
+        Pair<String, String> tokenRequestHeader =
+                new Pair<>(TOKEN_REQUEST_HEADER_KEY, TOKEN_REQUEST_HEADER_VALUE);
+
+        URI tokenEndpoint = null;
+        try {
+            tokenEndpoint = new URI(INSTANCE_TOKEN_URL);
+        } catch (Exception ex) {
+            log.debug("Failed to construct url: " + INSTANCE_IDENTITY_URL);
+            return false;
+        }
+        try {
+            token =
+                    fetcher.fetch(
+                            tokenEndpoint, "PUT", Collections.singletonList(tokenRequestHeader));
+        } catch (EMFClientException ex) {
+            log.debug("Failed to get response from: " + tokenEndpoint, ex);
+            return false;
+        }
+
+        Pair<String, String> metadataRequestTokenHeader =
+                new Pair<>(METADATA_REQUEST_TOKEN_HEADER_KEY, token);
         URI endpoint = null;
         try {
             endpoint = new URI(INSTANCE_IDENTITY_URL);
@@ -51,7 +81,12 @@ public class EC2Environment extends AgentBasedEnvironment {
             return false;
         }
         try {
-            metadata = fetcher.fetch(endpoint, EC2Metadata.class);
+            metadata =
+                    fetcher.fetch(
+                            endpoint,
+                            "GET",
+                            EC2Metadata.class,
+                            Collections.singletonList(metadataRequestTokenHeader));
             return true;
         } catch (EMFClientException ex) {
             log.debug("Failed to get response from: " + endpoint, ex);

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/environment/ResourceFetcher.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/environment/ResourceFetcher.java
@@ -23,7 +23,10 @@ import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.Proxy;
 import java.net.URI;
+import java.util.Collections;
+import java.util.List;
 import lombok.extern.slf4j.Slf4j;
+import org.javatuples.Pair;
 import software.amazon.cloudwatchlogs.emf.exception.EMFClientException;
 import software.amazon.cloudwatchlogs.emf.util.IOUtils;
 import software.amazon.cloudwatchlogs.emf.util.Jackson;
@@ -33,8 +36,22 @@ public class ResourceFetcher {
 
     /** Fetch a json object from a given uri and deserialize it to the specified class: clazz. */
     <T> T fetch(URI endpoint, Class<T> clazz) {
-        String response = doReadResource(endpoint, "GET");
+        String response = doReadResource(endpoint, "GET", Collections.emptyList());
         return Jackson.fromJsonString(response, clazz);
+    }
+
+    /**
+     * Request a json object from a given uri with the provided headers and deserialize it to the
+     * specified class: clazz.
+     */
+    <T> T fetch(URI endpoint, String method, Class<T> clazz, List<Pair<String, String>> headers) {
+        String response = doReadResource(endpoint, method, headers);
+        return Jackson.fromJsonString(response, clazz);
+    }
+
+    /** Request a string from a given uri with the provided headers */
+    String fetch(URI endpoint, String method, List<Pair<String, String>> headers) {
+        return doReadResource(endpoint, method, headers);
     }
 
     /**
@@ -42,15 +59,14 @@ public class ResourceFetcher {
      * Jackson ObjectMapper.
      */
     <T> T fetch(URI endpoint, ObjectMapper objectMapper, Class<T> clazz) {
-        String response = doReadResource(endpoint, "GET");
+        String response = doReadResource(endpoint, "GET", Collections.emptyList());
         return Jackson.fromJsonString(response, objectMapper, clazz);
     }
 
-    private String doReadResource(URI endpoint, String method) {
+    private String doReadResource(URI endpoint, String method, List<Pair<String, String>> headers) {
         InputStream inputStream = null;
         try {
-
-            HttpURLConnection connection = connectToEndpoint(endpoint, method);
+            HttpURLConnection connection = connectToEndpoint(endpoint, method, headers);
 
             int statusCode = connection.getResponseCode();
 
@@ -105,13 +121,16 @@ public class ResourceFetcher {
         }
     }
 
-    private HttpURLConnection connectToEndpoint(URI endpoint, String method) throws IOException {
+    private HttpURLConnection connectToEndpoint(
+            URI endpoint, String method, List<Pair<String, String>> headers) throws IOException {
         HttpURLConnection connection =
                 (HttpURLConnection) endpoint.toURL().openConnection(Proxy.NO_PROXY);
         connection.setConnectTimeout(1000);
         connection.setReadTimeout(1000);
         connection.setRequestMethod(method);
         connection.setDoOutput(true);
+        headers.forEach(
+                header -> connection.setRequestProperty(header.getValue0(), header.getValue1()));
 
         connection.connect();
 

--- a/src/test/java/software/amazon/cloudwatchlogs/emf/environment/EC2EnvironmentTest.java
+++ b/src/test/java/software/amazon/cloudwatchlogs/emf/environment/EC2EnvironmentTest.java
@@ -49,9 +49,11 @@ public class EC2EnvironmentTest {
         environment = new EC2Environment(config, fetcher);
     }
 
+    @SuppressWarnings("unchecked")
     @Test
     public void testProbeReturnFalse() {
-        when(fetcher.fetch(any(), any())).thenThrow(new EMFClientException("Invalid URL"));
+        when(fetcher.fetch(any(), any(), (Class<Object>) any(), any()))
+                .thenThrow(new EMFClientException("Invalid URL"));
 
         assertFalse(environment.probe());
     }
@@ -71,8 +73,10 @@ public class EC2EnvironmentTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void testGetTypeReturnDefined() {
-        when(fetcher.fetch(any(), any())).thenReturn(new EC2Environment.EC2Metadata());
+        when(fetcher.fetch(any(), any(), (Class<Object>) any(), any()))
+                .thenReturn(new EC2Environment.EC2Metadata());
         environment.probe();
         assertEquals(environment.getType(), "AWS::EC2::Instance");
     }
@@ -87,10 +91,11 @@ public class EC2EnvironmentTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void testConfigureContext() {
         EC2Environment.EC2Metadata metadata = new EC2Environment.EC2Metadata();
         getRandomMetadata(metadata);
-        when(fetcher.fetch(any(), any())).thenReturn(metadata);
+        when(fetcher.fetch(any(), any(), (Class<Object>) any(), any())).thenReturn(metadata);
         environment.probe();
 
         MetricsContext context = new MetricsContext();

--- a/src/test/java/software/amazon/cloudwatchlogs/emf/environment/ECSEnvironmentTest.java
+++ b/src/test/java/software/amazon/cloudwatchlogs/emf/environment/ECSEnvironmentTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.javafaker.Faker;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -68,7 +69,7 @@ public class ECSEnvironmentTest {
         String uri = "http://ecs-metata.com";
         PowerMockito.when(SystemWrapper.getenv("ECS_CONTAINER_METADATA_URI")).thenReturn(uri);
         ECSEnvironment.ECSMetadata metadata = new ECSEnvironment.ECSMetadata();
-        when(fetcher.fetch(any(), any(), any())).thenReturn(metadata);
+        when(fetcher.fetch(any(), (ObjectMapper) any(), any())).thenReturn(metadata);
 
         assertTrue(environment.probe());
     }
@@ -81,7 +82,7 @@ public class ECSEnvironmentTest {
         ECSEnvironment.ECSMetadata metadata = new ECSEnvironment.ECSMetadata();
         metadata.image = "testAccount.dkr.ecr.us-west-2.amazonaws.com/testImage:latest";
         metadata.labels = new HashMap<>();
-        when(fetcher.fetch(any(), any(), any())).thenReturn(metadata);
+        when(fetcher.fetch(any(), (ObjectMapper) any(), any())).thenReturn(metadata);
 
         assertTrue(environment.probe());
         assertEquals(environment.getName(), "testImage:latest");
@@ -122,7 +123,8 @@ public class ECSEnvironmentTest {
         PowerMockito.when(SystemWrapper.getenv("FLUENT_HOST")).thenReturn(fluentHost);
 
         environment.probe();
-        when(fetcher.fetch(any(), any(), any())).thenReturn(new ECSEnvironment.ECSMetadata());
+        when(fetcher.fetch(any(), (ObjectMapper) any(), any()))
+                .thenReturn(new ECSEnvironment.ECSMetadata());
         ArgumentCaptor<String> argument = ArgumentCaptor.forClass(String.class);
         Mockito.verify(config, times(1)).setAgentEndpoint(argument.capture());
         assertEquals(
@@ -155,7 +157,7 @@ public class ECSEnvironmentTest {
         PowerMockito.when(SystemWrapper.getenv("ECS_CONTAINER_METADATA_URI")).thenReturn(uri);
         ECSEnvironment.ECSMetadata metadata = new ECSEnvironment.ECSMetadata();
         getRandomMetadata(metadata);
-        when(fetcher.fetch(any(), any(), any())).thenReturn(metadata);
+        when(fetcher.fetch(any(), (ObjectMapper) any(), any())).thenReturn(metadata);
 
         environment.probe();
 


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*

IMDSv2 is a session-oriented method of retrieving EC2 instance metadata,
as opposed to the request/response method of IMDSv1.

https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
