### PR TITLE
Use the default Gradle configuration for the java canary

### DIFF
--- a/canarytests/agent/build.gradle
+++ b/canarytests/agent/build.gradle
@@ -8,7 +8,7 @@ repositories {
 
 dependencies {
     implementation "software.amazon.awssdk:cloudwatch:2.13.54"
-    implementation project(path:rootProject.path, configuration:'archives')
+    implementation project(path:rootProject.path)
     implementation  "org.apache.logging.log4j:log4j-api:2.13.3"
     implementation "org.apache.logging.log4j:log4j-core:2.13.3"
     implementation "org.apache.logging.log4j:log4j-slf4j-impl:2.13.3"


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Use the default Gradle configuration for the java canary. We add no dependencies to the archives configuration, causing NoClassDefFoundErrors in the canary at runtime. This resolves those issues.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
