### PR TITLE
fix: prevent putDimensions from storing duplicate dimensions

### DIFF
--- a/src/main/java/software/amazon/cloudwatchlogs/emf/model/MetricDirective.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/model/MetricDirective.java
@@ -52,6 +52,11 @@ class MetricDirective {
     }
 
     void putDimensionSet(DimensionSet dimensionSet) {
+        if (dimensions.stream()
+                .anyMatch(dim -> dim.getDimensionKeys().equals(dimensionSet.getDimensionKeys()))) {
+            return;
+        }
+
         dimensions.add(dimensionSet);
     }
 

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/model/MetricDirective.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/model/MetricDirective.java
@@ -51,12 +51,16 @@ class MetricDirective {
         shouldUseDefaultDimension = true;
     }
 
+    /**
+     * Adds a dimension set to the end of the collection.
+     *
+     * @param dimensionSet
+     */
     void putDimensionSet(DimensionSet dimensionSet) {
-        if (dimensions.stream()
-                .anyMatch(dim -> dim.getDimensionKeys().equals(dimensionSet.getDimensionKeys()))) {
-            return;
-        }
-
+        // Duplicate dimensions sets are removed before being added to the end of the collection.
+        // This ensures only latest dimension value is used as a target member on the root EMF node.
+        // This operation is O(n^2), but acceptable given sets are capped at 10 dimensions
+        dimensions.removeIf(dim -> dim.getDimensionKeys().equals(dimensionSet.getDimensionKeys()));
         dimensions.add(dimensionSet);
     }
 

--- a/src/test/java/software/amazon/cloudwatchlogs/emf/model/MetricDirectiveTest.java
+++ b/src/test/java/software/amazon/cloudwatchlogs/emf/model/MetricDirectiveTest.java
@@ -161,8 +161,8 @@ public class MetricDirectiveTest {
         String serializedMetricDirective = objectMapper.writeValueAsString(metricDirective);
 
         assertEquals(
-                serializedMetricDirective,
-                "{\"Dimensions\":[[\"Instance\",\"Region\"],[\"Instance\"],[\"Region\"],[]],\"Metrics\":[],\"Namespace\":\"aws-embedded-metrics\"}");
+                "{\"Dimensions\":[[\"Instance\",\"Region\"],[\"Instance\"],[\"Region\"],[]],\"Metrics\":[],\"Namespace\":\"aws-embedded-metrics\"}",
+                serializedMetricDirective);
     }
 
     @Test

--- a/src/test/java/software/amazon/cloudwatchlogs/emf/model/MetricDirectiveTest.java
+++ b/src/test/java/software/amazon/cloudwatchlogs/emf/model/MetricDirectiveTest.java
@@ -102,7 +102,7 @@ public class MetricDirectiveTest {
     }
 
     @Test
-    public void testPutMultipleDimensionSets() throws JsonProcessingException {
+    public void testPutDimensionSetWhenMultipleDimensionSets() throws JsonProcessingException {
         MetricDirective metricDirective = new MetricDirective();
         metricDirective.putDimensionSet(DimensionSet.of("Region", "us-east-1"));
         metricDirective.putDimensionSet(DimensionSet.of("Instance", "inst-1"));
@@ -115,14 +115,16 @@ public class MetricDirectiveTest {
     }
 
     @Test
-    public void testPutMultipleDuplicateDimensionSets() throws JsonProcessingException {
+    public void testPutDimensionSetWhenDuplicateDimensionSets() throws JsonProcessingException {
         MetricDirective metricDirective = new MetricDirective();
+        metricDirective.putDimensionSet(new DimensionSet());
         metricDirective.putDimensionSet(DimensionSet.of("Region", "us-east-1"));
         metricDirective.putDimensionSet(
                 DimensionSet.of("Region", "us-east-1", "Instance", "inst-1"));
         metricDirective.putDimensionSet(
                 DimensionSet.of("Instance", "inst-1", "Region", "us-east-1"));
         metricDirective.putDimensionSet(DimensionSet.of("Instance", "inst-1"));
+        metricDirective.putDimensionSet(new DimensionSet());
         metricDirective.putDimensionSet(DimensionSet.of("Region", "us-east-1"));
         metricDirective.putDimensionSet(
                 DimensionSet.of("Region", "us-east-1", "Instance", "inst-1"));
@@ -134,7 +136,33 @@ public class MetricDirectiveTest {
 
         assertEquals(
                 serializedMetricDirective,
-                "{\"Dimensions\":[[\"Region\"],[\"Region\",\"Instance\"],[\"Instance\"]],\"Metrics\":[],\"Namespace\":\"aws-embedded-metrics\"}");
+                "{\"Dimensions\":[[],[\"Region\"],[\"Instance\",\"Region\"],[\"Instance\"]],\"Metrics\":[],\"Namespace\":\"aws-embedded-metrics\"}");
+    }
+
+    @Test
+    public void testPutDimensionSetWhenDuplicateDimensionSetsWillSortCorrectly()
+            throws JsonProcessingException {
+        MetricDirective metricDirective = new MetricDirective();
+        metricDirective.putDimensionSet(new DimensionSet());
+        metricDirective.putDimensionSet(DimensionSet.of("Region", "us-east-1"));
+        metricDirective.putDimensionSet(
+                DimensionSet.of("Region", "us-east-1", "Instance", "inst-1"));
+        metricDirective.putDimensionSet(
+                DimensionSet.of("Instance", "inst-1", "Region", "us-east-1"));
+        metricDirective.putDimensionSet(DimensionSet.of("Instance", "inst-1"));
+        metricDirective.putDimensionSet(
+                DimensionSet.of("Region", "us-east-1", "Instance", "inst-1"));
+        metricDirective.putDimensionSet(
+                DimensionSet.of("Instance", "inst-1", "Region", "us-east-1"));
+        metricDirective.putDimensionSet(DimensionSet.of("Instance", "inst-1"));
+        metricDirective.putDimensionSet(DimensionSet.of("Region", "us-east-1"));
+        metricDirective.putDimensionSet(new DimensionSet());
+
+        String serializedMetricDirective = objectMapper.writeValueAsString(metricDirective);
+
+        assertEquals(
+                serializedMetricDirective,
+                "{\"Dimensions\":[[\"Instance\",\"Region\"],[\"Instance\"],[\"Region\"],[]],\"Metrics\":[],\"Namespace\":\"aws-embedded-metrics\"}");
     }
 
     @Test

--- a/src/test/java/software/amazon/cloudwatchlogs/emf/model/MetricDirectiveTest.java
+++ b/src/test/java/software/amazon/cloudwatchlogs/emf/model/MetricDirectiveTest.java
@@ -135,8 +135,8 @@ public class MetricDirectiveTest {
         String serializedMetricDirective = objectMapper.writeValueAsString(metricDirective);
 
         assertEquals(
-                serializedMetricDirective,
-                "{\"Dimensions\":[[],[\"Region\"],[\"Instance\",\"Region\"],[\"Instance\"]],\"Metrics\":[],\"Namespace\":\"aws-embedded-metrics\"}");
+                "{\"Dimensions\":[[],[\"Region\"],[\"Instance\",\"Region\"],[\"Instance\"]],\"Metrics\":[],\"Namespace\":\"aws-embedded-metrics\"}",
+                serializedMetricDirective);
     }
 
     @Test

--- a/src/test/java/software/amazon/cloudwatchlogs/emf/model/MetricDirectiveTest.java
+++ b/src/test/java/software/amazon/cloudwatchlogs/emf/model/MetricDirectiveTest.java
@@ -115,6 +115,29 @@ public class MetricDirectiveTest {
     }
 
     @Test
+    public void testPutMultipleDuplicateDimensionSets() throws JsonProcessingException {
+        MetricDirective metricDirective = new MetricDirective();
+        metricDirective.putDimensionSet(DimensionSet.of("Region", "us-east-1"));
+        metricDirective.putDimensionSet(
+                DimensionSet.of("Region", "us-east-1", "Instance", "inst-1"));
+        metricDirective.putDimensionSet(
+                DimensionSet.of("Instance", "inst-1", "Region", "us-east-1"));
+        metricDirective.putDimensionSet(DimensionSet.of("Instance", "inst-1"));
+        metricDirective.putDimensionSet(DimensionSet.of("Region", "us-east-1"));
+        metricDirective.putDimensionSet(
+                DimensionSet.of("Region", "us-east-1", "Instance", "inst-1"));
+        metricDirective.putDimensionSet(
+                DimensionSet.of("Instance", "inst-1", "Region", "us-east-1"));
+        metricDirective.putDimensionSet(DimensionSet.of("Instance", "inst-1"));
+
+        String serializedMetricDirective = objectMapper.writeValueAsString(metricDirective);
+
+        assertEquals(
+                serializedMetricDirective,
+                "{\"Dimensions\":[[\"Region\"],[\"Region\",\"Instance\"],[\"Instance\"]],\"Metrics\":[],\"Namespace\":\"aws-embedded-metrics\"}");
+    }
+
+    @Test
     public void testGetDimensionAfterSetDimensions() {
         MetricDirective metricDirective = new MetricDirective();
         metricDirective.setDefaultDimensions(DimensionSet.of("Dim", "Default"));


### PR DESCRIPTION
## Issue

https://github.com/awslabs/aws-embedded-metrics-java/issues/35 (related)

## Description of changes

This is the Java-equivalent bug-fix for prior issue in Node:
* https://github.com/awslabs/aws-embedded-metrics-node/issues/20
* https://github.com/awslabs/aws-embedded-metrics-node/pull/104

This change introduces the following behaviors:
1. dimension sets added through `#putDimensions` do not duplicate
2. duplicate dimension sets replace (and are sorted after) existing dimension sets such
that newer/latest dimension values are used by the root EMF node

Example:

```
putDimensions({ "keyA": "valueA1" })
putDimensions({ "keyA": "valueA2" })
putDimensions({ "keyA": "valueA3", "keyB": "valueB1" })
putDimensions({ "keyB": "valueB2", "keyA": "valueA4" })

// expected MetricsDirective dimensions:
[
  { "keyA": "valueA2" },
  { "keyB": "valueB2", "keyA": "valueA4" },
]

// expected EMF target members:
{
  "keyA": "valueA4",
  "keyB": "valueB2",
}
```

## Description of how you validated changes

Unit test updated to address edge case;
multiple dimension sets of variable size are added and checked.

Ran integration tests using Docker and compared results in CloudWatch.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
