### PR TITLE
Update README to better reflect current behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ putProperty("Device", new HashMap<String, String>() {{
 
 Adds a new set of dimensions that will be associated with all metric values.
 
-**WARNING**: Every distinct value for a dimension set will result in a new CloudWatch metric.
+**WARNING**: Each dimension set will result in a new CloudWatch metric (even dimension sets with the same values).
 If the cardinality of a particular value is expected to be high, you should consider
 using `setProperty` instead.
 
@@ -113,7 +113,7 @@ putDimensions(DimensionSet.of("Operation", "Aggregator", "DeviceType", "Actuator
 
 Explicitly override all dimensions. This will remove the default dimensions.
 
-**WARNING**: Every distinct value for a dimension set will result in a new CloudWatch metric.
+**WARNING**: Each dimension set will result in a new CloudWatch metric (even dimension sets with the same values).
 If the cardinality of a particular value is expected to be high, you should consider
 using `setProperty` instead.
 


### PR DESCRIPTION
*Description of changes:*
There's currently no limitation in the backend for providing multiple dimension sets with the same values. Each set will result in a separate metric.
So adjusting warning in README file to reflect that.
Will create a PR for `master` branch as well once this is approved.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
