### PR TITLE
Add support to clear custom dimensions and configure flush behavior on dimensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,9 +166,13 @@ setDimensions(
 )
 ```
 
-- MetricsLogger **resetDimensions**(boolean preserveDefault)
+- MetricsLogger **setDimensions**(boolean useDefault, DimensionSet... dimensionSets)
 
-Explicitly clear all custom dimensions. The behavior of whether default dimensions should be used can be changed by the boolean parameter.
+Override all custom dimensions, with an option to configure whether to use default dimensions.
+
+- MetricsLogger **resetDimensions**(boolean useDefault)
+
+Explicitly clear all custom dimensions. The behavior of whether default dimensions should be used can be configured by the input parameter.
 
 Examples:
 
@@ -203,7 +207,7 @@ setTimestamp(Instant.now())
 
 - **flush**()
 
-Flushes the current MetricsContext to the configured sink and resets all properties and metric values. The namespace and default dimensions will be preserved across flushes. The default behavior is to preserve all custom dimensions as well, but this can be disabled by invoking `setFlushPreserveDimensions(false)`.
+Flushes the current MetricsContext to the configured sink and resets all properties and metric values. The namespace and default dimensions will be preserved across flushes. Custom dimensions are preserved by default, but can be disabled by invoking `setFlushPreserveDimensions(false)`.
 
 Example:
 
@@ -219,7 +223,7 @@ flush();  // only default dimensions will be preserved after each flush()
 ```java
 setFlushPreserveDimensions(false);
 flush();
-resetDimensions(false);  // no dimensions will be preserved after each flush()
+resetDimensions(false);  // default dimensions are disabled; no dimensions will be preserved after each flush()
 ```
 
 ### Configuration

--- a/README.md
+++ b/README.md
@@ -166,6 +166,15 @@ setDimensions(
 )
 ```
 
+- MetricsLogger **resetDimensions**(boolean preserveDefault)
+
+Explicitly clear all custom dimensions. The behavior of whether default dimensions should be used can be changed by the boolean parameter.
+
+Examples:
+
+```java
+resetDimensions(false)  // this will clear all custom dimensions as well as disable default dimensions
+```
 
 - MetricsLogger **setNamespace**(String value)
 
@@ -194,7 +203,7 @@ setTimestamp(Instant.now())
 
 - **flush**()
 
-Flushes the current MetricsContext to the configured sink and resets all properties, dimensions and metric values. The namespace and default dimensions will be preserved across flushes.
+Flushes the current MetricsContext to the configured sink and resets all properties and metric values. The namespace and default dimensions will be preserved across flushes. The default behavior is to preserve all custom dimensions as well, but this can be disabled by invoking `flushPreserveDimensions(false)`.
 
 ### Configuration
 

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ setTimestamp(Instant.now())
 
 - **flush**()
 
-Flushes the current MetricsContext to the configured sink and resets all properties and metric values. The namespace and default dimensions will be preserved across flushes. Custom dimensions are preserved by default, but can be disabled by invoking `setFlushPreserveDimensions(false)`.
+Flushes the current MetricsContext to the configured sink and resets all properties and metric values. The namespace and default dimensions will be preserved across flushes. Custom dimensions are preserved by default, but this behavior can be disabled by invoking `setFlushPreserveDimensions(false)`, so that no custom dimensions would be preserved after each flushing thereafter.
 
 Example:
 

--- a/README.md
+++ b/README.md
@@ -203,7 +203,24 @@ setTimestamp(Instant.now())
 
 - **flush**()
 
-Flushes the current MetricsContext to the configured sink and resets all properties and metric values. The namespace and default dimensions will be preserved across flushes. The default behavior is to preserve all custom dimensions as well, but this can be disabled by invoking `flushPreserveDimensions(false)`.
+Flushes the current MetricsContext to the configured sink and resets all properties and metric values. The namespace and default dimensions will be preserved across flushes. The default behavior is to preserve all custom dimensions as well, but this can be disabled by invoking `setFlushPreserveDimensions(false)`.
+
+Example:
+
+```java
+flush();  // default dimensions and custom domensions will be preserved after each flush()
+```
+
+```java
+setFlushPreserveDimensions(false);
+flush();  // only default dimnesions will be preserved after each flush()
+```
+
+```java
+setFlushPreserveDimensions(false);
+flush();
+resetDimensions(false);  // no dimensions will be preserved after each flush()
+```
 
 ### Configuration
 

--- a/README.md
+++ b/README.md
@@ -208,12 +208,12 @@ Flushes the current MetricsContext to the configured sink and resets all propert
 Example:
 
 ```java
-flush();  // default dimensions and custom domensions will be preserved after each flush()
+flush();  // default dimensions and custom dimensions will be preserved after each flush()
 ```
 
 ```java
 setFlushPreserveDimensions(false);
-flush();  // only default dimnesions will be preserved after each flush()
+flush();  // only default dimensions will be preserved after each flush()
 ```
 
 ```java

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/logger/MetricsLogger.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/logger/MetricsLogger.java
@@ -126,7 +126,9 @@ public class MetricsLogger {
     }
 
     /**
-     * Overwrite custom dimensions on this MetricsLogger instance, with an option to preserve default dimensions.
+     * Overwrite custom dimensions on this MetricsLogger instance, with an option to preserve
+     * default dimensions.
+     *
      * @param preserveDefault indicates whether default dimensions should be used
      * @param dimensionSets the dimensionSets to set
      * @return the current logger

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/logger/MetricsLogger.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/logger/MetricsLogger.java
@@ -114,7 +114,7 @@ public class MetricsLogger {
     /**
      * Overwrite all dimensions on this MetricsLogger instance.
      *
-     * @param dimensionSets the dimensionSets to set.
+     * @param dimensionSets the dimensionSets to set
      * @see <a
      *     href="https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/cloudwatch_concepts.html#Dimension">CloudWatch
      *     Dimensions</a>
@@ -122,6 +122,17 @@ public class MetricsLogger {
      */
     public MetricsLogger setDimensions(DimensionSet... dimensionSets) {
         context.setDimensions(dimensionSets);
+        return this;
+    }
+
+    /**
+     * Overwrite custom dimensions on this MetricsLogger instance, with an option to preserve default dimensions.
+     * @param preserveDefault indicates whether default dimensions should be used
+     * @param dimensionSets the dimensionSets to set
+     * @return the current logger
+     */
+    public MetricsLogger setDimensions(boolean preserveDefault, DimensionSet... dimensionSets) {
+        context.setDimensions(preserveDefault, dimensionSets);
         return this;
     }
 

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/logger/MetricsLogger.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/logger/MetricsLogger.java
@@ -129,24 +129,24 @@ public class MetricsLogger {
      * Overwrite custom dimensions on this MetricsLogger instance, with an option to preserve
      * default dimensions.
      *
-     * @param preserveDefault indicates whether default dimensions should be used
+     * @param useDefault indicates whether default dimensions should be used
      * @param dimensionSets the dimensionSets to set
      * @return the current logger
      */
-    public MetricsLogger setDimensions(boolean preserveDefault, DimensionSet... dimensionSets) {
-        context.setDimensions(preserveDefault, dimensionSets);
+    public MetricsLogger setDimensions(boolean useDefault, DimensionSet... dimensionSets) {
+        context.setDimensions(useDefault, dimensionSets);
         return this;
     }
 
     /**
-     * Clear all custom dimensions on this MetricsLogger instance. The state of whether default
-     * dimensions should be used can be changed by this method.
+     * Clear all custom dimensions on this MetricsLogger instance. Whether default dimensions should
+     * be used can be configured by the input parameter.
      *
-     * @param preserveDefault indicates whether default dimensions should be used
+     * @param useDefault indicates whether default dimensions should be used
      * @return the current logger
      */
-    public MetricsLogger resetDimensions(boolean preserveDefault) {
-        context.resetDimensions(preserveDefault);
+    public MetricsLogger resetDimensions(boolean useDefault) {
+        context.resetDimensions(useDefault);
         return this;
     }
 

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/model/MetricDirective.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/model/MetricDirective.java
@@ -100,6 +100,7 @@ class MetricDirective {
 
     /**
      * Override existing dimensions. Default dimensions are preserved optionally.
+     *
      * @param preserveDefault indicates whether default dimensions should be used
      * @param dimensionSets the dimensionSets to be set
      */

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/model/MetricDirective.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/model/MetricDirective.java
@@ -99,6 +99,16 @@ class MetricDirective {
     }
 
     /**
+     * Override existing dimensions. Default dimensions are preserved optionally.
+     * @param preserveDefault indicates whether default dimensions should be used
+     * @param dimensionSets the dimensionSets to be set
+     */
+    void setDimensions(boolean preserveDefault, List<DimensionSet> dimensionSets) {
+        shouldUseDefaultDimension = preserveDefault;
+        dimensions = new ArrayList<>(dimensionSets);
+    }
+
+    /**
      * Clear existing custom dimensions.
      *
      * @param preserveDefault indicates whether default dimensions should be used

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/model/MetricDirective.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/model/MetricDirective.java
@@ -99,6 +99,16 @@ class MetricDirective {
     }
 
     /**
+     * Clear existing custom dimensions.
+     *
+     * @param preserveDefault indicates whether default dimensions should be used
+     */
+    void resetDimensions(boolean preserveDefault) {
+        shouldUseDefaultDimension = preserveDefault;
+        dimensions = Collections.synchronizedList(new ArrayList<>());
+    }
+
+    /**
      * Return all the dimension sets. If there's a default dimension set, the custom dimensions are
      * prepended with the default dimensions.
      */
@@ -136,6 +146,21 @@ class MetricDirective {
         metricDirective.setDimensions(this.dimensions);
         metricDirective.setNamespace(this.namespace);
         metricDirective.shouldUseDefaultDimension = this.shouldUseDefaultDimension;
+        return metricDirective;
+    }
+
+    /**
+     * Create a copy of the metric directive without having the existing metrics and custom
+     * dimensions. The original state of default dimensions are preserved.
+     *
+     * @return an object of metric directive
+     */
+    MetricDirective copyWithoutMetricsAndDimensions() {
+        MetricDirective metricDirective = new MetricDirective();
+        metricDirective.setDefaultDimensions(this.defaultDimensions);
+        metricDirective.setNamespace(this.namespace);
+        metricDirective.shouldUseDefaultDimension = this.shouldUseDefaultDimension;
+
         return metricDirective;
     }
 }

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/model/MetricDirective.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/model/MetricDirective.java
@@ -105,7 +105,7 @@ class MetricDirective {
      */
     void resetDimensions(boolean preserveDefault) {
         shouldUseDefaultDimension = preserveDefault;
-        dimensions = Collections.synchronizedList(new ArrayList<>());
+        dimensions = new ArrayList<>();
     }
 
     /**

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/model/MetricDirective.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/model/MetricDirective.java
@@ -101,21 +101,21 @@ class MetricDirective {
     /**
      * Override existing dimensions. Default dimensions are preserved optionally.
      *
-     * @param preserveDefault indicates whether default dimensions should be used
+     * @param useDefault indicates whether default dimensions should be used
      * @param dimensionSets the dimensionSets to be set
      */
-    void setDimensions(boolean preserveDefault, List<DimensionSet> dimensionSets) {
-        shouldUseDefaultDimension = preserveDefault;
+    void setDimensions(boolean useDefault, List<DimensionSet> dimensionSets) {
+        shouldUseDefaultDimension = useDefault;
         dimensions = new ArrayList<>(dimensionSets);
     }
 
     /**
      * Clear existing custom dimensions.
      *
-     * @param preserveDefault indicates whether default dimensions should be used
+     * @param useDefault indicates whether default dimensions should be used
      */
-    void resetDimensions(boolean preserveDefault) {
-        shouldUseDefaultDimension = preserveDefault;
+    void resetDimensions(boolean useDefault) {
+        shouldUseDefaultDimension = useDefault;
         dimensions = new ArrayList<>();
     }
 

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/model/MetricsContext.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/model/MetricsContext.java
@@ -187,6 +187,15 @@ public class MetricsContext {
     }
 
     /**
+     * Update the dimensions. Default dimensions are preserved optionally.
+     * @param preserveDefault indicates whether default dimensions should be used
+     * @param dimensionSets the dimensionSets to set
+     */
+    public void setDimensions(boolean preserveDefault, DimensionSet... dimensionSets) {
+        metricDirective.setDimensions(preserveDefault, Arrays.asList(dimensionSets));
+    }
+
+    /**
      * Reset the dimensions. This would clear all custom dimensions.
      *
      * @param preserveDefault indicates whether default dimensions should be used

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/model/MetricsContext.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/model/MetricsContext.java
@@ -187,6 +187,15 @@ public class MetricsContext {
     }
 
     /**
+     * Reset the dimensions. This would clear all custom dimensions.
+     *
+     * @param preserveDefault indicates whether default dimensions should be used
+     */
+    public void resetDimensions(boolean preserveDefault) {
+        metricDirective.resetDimensions(preserveDefault);
+    }
+
+    /**
      * Add a key-value pair to the metadata
      *
      * @param key the name of the key
@@ -213,6 +222,11 @@ public class MetricsContext {
     /** @return Creates an independently flushable context. */
     public MetricsContext createCopyWithContext() {
         return new MetricsContext(metricDirective.copyWithoutMetrics());
+    }
+
+    /** @return Creates an independently flushable context without metrics and custom dimensions */
+    public MetricsContext createCopyWithContextWithoutDimensions() {
+        return new MetricsContext(metricDirective.copyWithoutMetricsAndDimensions());
     }
 
     /**

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/model/MetricsContext.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/model/MetricsContext.java
@@ -189,20 +189,20 @@ public class MetricsContext {
     /**
      * Update the dimensions. Default dimensions are preserved optionally.
      *
-     * @param preserveDefault indicates whether default dimensions should be used
+     * @param useDefault indicates whether default dimensions should be used
      * @param dimensionSets the dimensionSets to set
      */
-    public void setDimensions(boolean preserveDefault, DimensionSet... dimensionSets) {
-        metricDirective.setDimensions(preserveDefault, Arrays.asList(dimensionSets));
+    public void setDimensions(boolean useDefault, DimensionSet... dimensionSets) {
+        metricDirective.setDimensions(useDefault, Arrays.asList(dimensionSets));
     }
 
     /**
      * Reset the dimensions. This would clear all custom dimensions.
      *
-     * @param preserveDefault indicates whether default dimensions should be used
+     * @param useDefault indicates whether default dimensions should be used
      */
-    public void resetDimensions(boolean preserveDefault) {
-        metricDirective.resetDimensions(preserveDefault);
+    public void resetDimensions(boolean useDefault) {
+        metricDirective.resetDimensions(useDefault);
     }
 
     /**

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/model/MetricsContext.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/model/MetricsContext.java
@@ -188,6 +188,7 @@ public class MetricsContext {
 
     /**
      * Update the dimensions. Default dimensions are preserved optionally.
+     *
      * @param preserveDefault indicates whether default dimensions should be used
      * @param dimensionSets the dimensionSets to set
      */

--- a/src/test/java/software/amazon/cloudwatchlogs/emf/logger/MetricsLoggerTest.java
+++ b/src/test/java/software/amazon/cloudwatchlogs/emf/logger/MetricsLoggerTest.java
@@ -94,6 +94,38 @@ public class MetricsLoggerTest {
     }
 
     @Test
+    public void testResetWithDefaultDimensions() {
+        String dimensionName = "dim";
+        String dimensionValue = "dimValue";
+        logger.putDimensions(DimensionSet.of("foo", "bar"));
+        logger.resetDimensions(true);
+        logger.putDimensions(DimensionSet.of(dimensionName, dimensionValue));
+        logger.flush();
+
+        Assert.assertEquals(sink.getContext().getDimensions().size(), 1);
+        Assert.assertEquals(sink.getContext().getDimensions().get(0).getDimensionKeys().size(), 4);
+        Assert.assertEquals(
+                sink.getContext().getDimensions().get(0).getDimensionValue(dimensionName),
+                dimensionValue);
+    }
+
+    @Test
+    public void testResetWithoutDefaultDimensions() {
+        String dimensionName = "dim";
+        String dimensionValue = "dimValue";
+        logger.putDimensions(DimensionSet.of("foo", "bar"));
+        logger.resetDimensions(false);
+        logger.putDimensions(DimensionSet.of(dimensionName, dimensionValue));
+        logger.flush();
+
+        Assert.assertEquals(sink.getContext().getDimensions().size(), 1);
+        Assert.assertEquals(sink.getContext().getDimensions().get(0).getDimensionKeys().size(), 1);
+        Assert.assertEquals(
+                sink.getContext().getDimensions().get(0).getDimensionValue(dimensionName),
+                dimensionValue);
+    }
+
+    @Test
     public void testOverridePreviousDimensions() {
 
         String dimensionName = "dim";
@@ -227,6 +259,20 @@ public class MetricsLoggerTest {
 
         logger.flush();
         expectDimension("Name", "Test");
+    }
+
+    @Test
+    public void testFlushDoesntPreserveDimensions() {
+        logger.putDimensions(DimensionSet.of("Name", "Test"));
+        logger.setFlushPreserveDimensions(false);
+
+        logger.flush();
+        Assert.assertEquals(sink.getContext().getDimensions().get(0).getDimensionKeys().size(), 4);
+        expectDimension("Name", "Test");
+
+        logger.flush();
+        Assert.assertEquals(sink.getContext().getDimensions().get(0).getDimensionKeys().size(), 3);
+        expectDimension("Name", null);
     }
 
     @Test

--- a/src/test/java/software/amazon/cloudwatchlogs/emf/logger/MetricsLoggerTest.java
+++ b/src/test/java/software/amazon/cloudwatchlogs/emf/logger/MetricsLoggerTest.java
@@ -142,6 +142,21 @@ public class MetricsLoggerTest {
     }
 
     @Test
+    public void testSetDimensionsAndPreserveDefault() {
+        String dimensionName = "dim";
+        String dimensionValue = "dimValue";
+        logger.putDimensions(DimensionSet.of("foo", "bar"));
+        logger.setDimensions(true, DimensionSet.of(dimensionName, dimensionValue));
+        logger.flush();
+
+        Assert.assertEquals(sink.getContext().getDimensions().size(), 1);
+        Assert.assertEquals(sink.getContext().getDimensions().get(0).getDimensionKeys().size(), 4);
+        Assert.assertEquals(
+                sink.getContext().getDimensions().get(0).getDimensionValue(dimensionName),
+                dimensionValue);
+    }
+
+    @Test
     public void testSetNamespace() {
 
         String namespace = "testNamespace";


### PR DESCRIPTION
*Issue #, if available:*
#35, #91

*Description of changes:*
Added a resetDimensions(boolean useDefault) method for clearing custom dimensions; added a boolean field to MetricsLogger to control the behavior of whether to preserve custom dimensions after each flush(); adjusted README to reflect the correct behavior of flush() and new method.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
