### PR TITLE
Support 30 metric dimensions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ allprojects {
 		targetCompatibility = '1.8'
 	}
 
-	version = '1.0.6'
+	version = '2.0.0'
 }
 
 java {

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/exception/DimensionSetExceededException.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/exception/DimensionSetExceededException.java
@@ -14,16 +14,20 @@
  *   limitations under the License.
  */
 
-package software.amazon.cloudwatchlogs.emf;
+package software.amazon.cloudwatchlogs.emf.exception;
 
-public class Constants {
-    public static final int DEFAULT_AGENT_PORT = 25888;
+import software.amazon.cloudwatchlogs.emf.Constants;
 
-    public static final String UNKNOWN = "Unknown";
+public class DimensionSetExceededException extends RuntimeException {
 
-    public static final int MAX_METRICS_PER_EVENT = 100;
+    public DimensionSetExceededException() {
+        super(
+                "Maximum number of dimensions allowed are "
+                        + Constants.MAX_DIMENSION_SET_SIZE
+                        + ". Account for default dimensions if not using setDimensions.");
+    }
 
-    public static final int MAX_DIMENSION_SET_SIZE = 30;
-
-    public static final int MAX_DATAPOINTS_PER_METRIC = 100;
+    public DimensionSetExceededException(String message) {
+        super(message);
+    }
 }

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/model/DimensionSet.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/model/DimensionSet.java
@@ -22,6 +22,8 @@ import java.util.Set;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import software.amazon.cloudwatchlogs.emf.Constants;
+import software.amazon.cloudwatchlogs.emf.exception.DimensionSetExceededException;
 
 /** A combination of dimension values. */
 public class DimensionSet {
@@ -149,6 +151,10 @@ public class DimensionSet {
      * @param value Value of the dimension
      */
     public void addDimension(String dimension, String value) {
+        if (this.getDimensionKeys().size() >= Constants.MAX_DIMENSION_SET_SIZE) {
+            throw new DimensionSetExceededException();
+        }
+
         this.getDimensionRecords().put(dimension, value);
     }
 
@@ -161,6 +167,12 @@ public class DimensionSet {
      */
     public DimensionSet add(DimensionSet other) {
         DimensionSet mergedDimensionSet = new DimensionSet();
+        int mergedDimensionSetSize =
+                this.getDimensionKeys().size() + other.dimensionRecords.keySet().size();
+        if (mergedDimensionSetSize > Constants.MAX_DIMENSION_SET_SIZE) {
+            throw new DimensionSetExceededException();
+        }
+
         mergedDimensionSet.dimensionRecords.putAll(dimensionRecords);
         mergedDimensionSet.dimensionRecords.putAll(other.dimensionRecords);
         return mergedDimensionSet;

--- a/src/test/java/software/amazon/cloudwatchlogs/emf/model/DimensionSetTest.java
+++ b/src/test/java/software/amazon/cloudwatchlogs/emf/model/DimensionSetTest.java
@@ -1,0 +1,77 @@
+/*
+ *   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package software.amazon.cloudwatchlogs.emf.model;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+import software.amazon.cloudwatchlogs.emf.exception.DimensionSetExceededException;
+
+public class DimensionSetTest {
+    @Test
+    public void testAddDimension() {
+        int dimensionsToBeAdded = 30;
+        DimensionSet dimensionSet = generateDimensionSet(dimensionsToBeAdded);
+
+        assertEquals(dimensionsToBeAdded, dimensionSet.getDimensionKeys().size());
+    }
+
+    @Test
+    public void testAddDimensionLimitExceeded() {
+        Exception exception =
+                assertThrows(
+                        DimensionSetExceededException.class,
+                        () -> {
+                            int dimensionSetSize = 33;
+                            generateDimensionSet(dimensionSetSize);
+                        });
+
+        String expectedMessage = "Maximum number of dimensions";
+        String actualMessage = exception.getMessage();
+
+        assertTrue(actualMessage.contains(expectedMessage));
+    }
+
+    @Test
+    public void testMergeDimensionSets() {
+        Exception exception =
+                assertThrows(
+                        DimensionSetExceededException.class,
+                        () -> {
+                            int dimensionSetSize = 28;
+                            int otherDimensionSetSize = 5;
+                            DimensionSet dimensionSet = generateDimensionSet(dimensionSetSize);
+                            DimensionSet otherDimensionSet =
+                                    generateDimensionSet(otherDimensionSetSize);
+                            dimensionSet.add(otherDimensionSet);
+                        });
+        String expectedMessage = "Maximum number of dimensions";
+        String actualMessage = exception.getMessage();
+
+        assertTrue(actualMessage.contains(expectedMessage));
+    }
+
+    private DimensionSet generateDimensionSet(int numOfDimensions) {
+        DimensionSet dimensionSet = new DimensionSet();
+
+        for (int i = 0; i < numOfDimensions; i++) {
+            dimensionSet.addDimension("Dimension" + i, "value" + i);
+        }
+
+        return dimensionSet;
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Support 30 dimensions in a set for metrics and throw exception if the limit is exceeded.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
