### PR TITLE
Added logic for replacing colon in log group name and unit test

### DIFF
--- a/src/main/java/software/amazon/cloudwatchlogs/emf/environment/AgentBasedEnvironment.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/environment/AgentBasedEnvironment.java
@@ -45,7 +45,17 @@ public abstract class AgentBasedEnvironment implements Environment {
 
     @Override
     public String getLogGroupName() {
-        return config.getLogGroupName().orElse(getName() + "-metrics");
+        if (config.getLogGroupName().isPresent()) {
+            return config.getLogGroupName().get();
+        } else {
+            String serviceName = getName();
+            // for ECS services, replace "repo:tag" format with "repo-tag" to satisfy
+            // log group regex
+            if (serviceName.indexOf(':') != -1) {
+                serviceName = serviceName.replaceAll(":", "-");
+            }
+            return serviceName + "-metrics";
+        }
     }
 
     public String getLogStreamName() {

--- a/src/test/java/software/amazon/cloudwatchlogs/emf/environment/ECSEnvironmentTest.java
+++ b/src/test/java/software/amazon/cloudwatchlogs/emf/environment/ECSEnvironmentTest.java
@@ -151,6 +151,14 @@ public class ECSEnvironmentTest {
     }
 
     @Test
+    public void testGetLogGroupNameReplaceColon() {
+        String serviceName = "testRepo:testTag";
+        when(config.getServiceName()).thenReturn(Optional.of(serviceName));
+
+        assertEquals(environment.getLogGroupName(), "testRepo-testTag-metrics");
+    }
+
+    @Test
     public void testConfigureContext() throws UnknownHostException {
         PowerMockito.mockStatic(SystemWrapper.class);
         String uri = "http://ecs-metata.com";


### PR DESCRIPTION
*Issue #, if available:*
#65 

*Description of changes:*
Added logic to replace colon(:) with hyphen(-) when using the service name as part of the log group name. This prevents the violation for log group name regex when the service name is of format “repo:tag” in ECS environment, which is a bug when using the library to publish metrics in ECS without extra configuration.

*Measures for testing:*
Reproduced the issue in ECS environment with CloudWatch Agent for publishing metrics, then deployed with the new library and the issue is gone.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
