### PR TITLE
Change dockefile openjdk version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,8 +25,8 @@ group "software.amazon.cloudwatchlogs"
 
 allprojects {
 	compileJava {
-		sourceCompatibility = '1.8'
-		targetCompatibility = '1.8'
+		sourceCompatibility = JavaVersion.VERSION_11
+		targetCompatibility = JavaVersion.VERSION_11
 	}
 
 	version = '3.1.0'

--- a/canarytests/agent/Dockerfile
+++ b/canarytests/agent/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11-jdk-slim
+FROM openjdk:11
 RUN mkdir /app
 COPY build/libs/*.jar /app/agent.jar
 ENV JAVA_OPTS=""


### PR DESCRIPTION
*Description of changes:*

Docker image `openjdk:11-jdk-slim` is causing issues for the canary tests. Changing to `openjdk:11`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
