### PR TITLE
Missing dependency for canarytests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,7 +74,6 @@ dependencies {
 	testImplementation 'org.junit.jupiter:junit-jupiter-params:5.9.0'
 	testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.9.0'
 	testImplementation 'org.junit.vintage:junit-vintage-engine:5.9.0'
-	testImplementation 'org.apache.commons:commons-lang3:3.12.0'
 	testImplementation "org.mockito:mockito-core:2.+"
 	testImplementation "org.powermock:powermock-module-junit4:2.0.2"
 	testImplementation "org.powermock:powermock-api-mockito2:2.0.2"

--- a/canarytests/agent/build.gradle
+++ b/canarytests/agent/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     implementation "org.apache.logging.log4j:log4j-api:2.13.3"
     implementation "org.apache.logging.log4j:log4j-core:2.13.3"
     implementation "org.apache.logging.log4j:log4j-slf4j-impl:2.13.3"
+    implementation 'org.apache.commons:commons-lang3:3.12.0'
 }
 
 jar  {


### PR DESCRIPTION
*Description of changes:*
`canarytests` was missing `org.apache.commons:commons-lang3:3.12.0` and was failing.
This PR fixes that.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
