### PR TITLE
Change compatibility to java 1.8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ allprojects {
 		targetCompatibility = JavaVersion.VERSION_1_8
 	}
 
-	version = '4.0.0'
+	version = '4.0.1'
 }
 
 java {

--- a/build.gradle
+++ b/build.gradle
@@ -25,8 +25,8 @@ group "software.amazon.cloudwatchlogs"
 
 allprojects {
 	compileJava {
-		sourceCompatibility = JavaVersion.VERSION_11
-		targetCompatibility = JavaVersion.VERSION_11
+		sourceCompatibility = JavaVersion.VERSION_1_8
+		targetCompatibility = JavaVersion.VERSION_1_8
 	}
 
 	version = '4.0.0'


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
Some customers are unable to upgrade to version 4.x due to the change in java compatibility. Since our project doesn't require features from Java 11 we have decided to downgrade compatibility to 1.8.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
