### PR TITLE
Skip adding dimensions with empty dimension value into default dimension

### DIFF
--- a/src/main/java/software/amazon/cloudwatchlogs/emf/logger/MetricsLogger.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/logger/MetricsLogger.java
@@ -33,6 +33,7 @@ import software.amazon.cloudwatchlogs.emf.model.DimensionSet;
 import software.amazon.cloudwatchlogs.emf.model.MetricsContext;
 import software.amazon.cloudwatchlogs.emf.model.Unit;
 import software.amazon.cloudwatchlogs.emf.sinks.ISink;
+import software.amazon.cloudwatchlogs.emf.util.StringUtils;
 
 /**
  * A metrics logger. Use this interface to publish logs to CloudWatch Logs and extract metrics to
@@ -259,17 +260,23 @@ public class MetricsLogger {
         return this;
     }
 
-    @SneakyThrows
     private void configureContextForEnvironment(MetricsContext context, Environment environment) {
         if (context.hasDefaultDimensions()) {
             return;
         }
         DimensionSet defaultDimension = new DimensionSet();
-        defaultDimension.addDimension("LogGroup", environment.getLogGroupName());
-        defaultDimension.addDimension("ServiceName", environment.getName());
-        defaultDimension.addDimension("ServiceType", environment.getType());
+        setDefaultDimension(defaultDimension, "LogGroup", environment.getLogGroupName());
+        setDefaultDimension(defaultDimension, "ServiceName",  environment.getName());
+        setDefaultDimension(defaultDimension, "ServiceType", environment.getType());
         context.setDefaultDimensions(defaultDimension);
         environment.configureContext(context);
+    }
+
+    @SneakyThrows
+    private void setDefaultDimension(DimensionSet defaultDimension, String dimKey, String dimVal) {
+        if (!StringUtils.isNullOrEmpty(dimVal)) {
+            defaultDimension.addDimension(dimKey, dimVal);
+        }
     }
 
     private MetricsLogger applyReadLock(Supplier<MetricsLogger> any) {

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/logger/MetricsLogger.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/logger/MetricsLogger.java
@@ -275,7 +275,7 @@ public class MetricsLogger {
     private void setDefaultDimension(DimensionSet defaultDimension, String dimKey, String dimVal) {
         try {
             defaultDimension.addDimension(dimKey, dimVal);
-        } catch (InvalidDimensionException | DimensionSetExceededException e) {
+        } catch (InvalidDimensionException | DimensionSetExceededException ignored) {
         }
     }
 

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/logger/MetricsLogger.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/logger/MetricsLogger.java
@@ -26,6 +26,8 @@ import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import software.amazon.cloudwatchlogs.emf.environment.Environment;
 import software.amazon.cloudwatchlogs.emf.environment.EnvironmentProvider;
+import software.amazon.cloudwatchlogs.emf.exception.DimensionSetExceededException;
+import software.amazon.cloudwatchlogs.emf.exception.InvalidDimensionException;
 import software.amazon.cloudwatchlogs.emf.exception.InvalidMetricException;
 import software.amazon.cloudwatchlogs.emf.exception.InvalidNamespaceException;
 import software.amazon.cloudwatchlogs.emf.exception.InvalidTimestampException;
@@ -33,7 +35,6 @@ import software.amazon.cloudwatchlogs.emf.model.DimensionSet;
 import software.amazon.cloudwatchlogs.emf.model.MetricsContext;
 import software.amazon.cloudwatchlogs.emf.model.Unit;
 import software.amazon.cloudwatchlogs.emf.sinks.ISink;
-import software.amazon.cloudwatchlogs.emf.util.StringUtils;
 
 /**
  * A metrics logger. Use this interface to publish logs to CloudWatch Logs and extract metrics to
@@ -266,16 +267,17 @@ public class MetricsLogger {
         }
         DimensionSet defaultDimension = new DimensionSet();
         setDefaultDimension(defaultDimension, "LogGroup", environment.getLogGroupName());
-        setDefaultDimension(defaultDimension, "ServiceName",  environment.getName());
+        setDefaultDimension(defaultDimension, "ServiceName", environment.getName());
         setDefaultDimension(defaultDimension, "ServiceType", environment.getType());
         context.setDefaultDimensions(defaultDimension);
         environment.configureContext(context);
     }
 
-    @SneakyThrows
     private void setDefaultDimension(DimensionSet defaultDimension, String dimKey, String dimVal) {
-        if (!StringUtils.isNullOrEmpty(dimVal)) {
+        try {
             defaultDimension.addDimension(dimKey, dimVal);
+        } catch (InvalidDimensionException | DimensionSetExceededException e) {
+            // just do nothing
         }
     }
 

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/logger/MetricsLogger.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/logger/MetricsLogger.java
@@ -22,7 +22,6 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Supplier;
 import lombok.Getter;
 import lombok.Setter;
-import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import software.amazon.cloudwatchlogs.emf.environment.Environment;
 import software.amazon.cloudwatchlogs.emf.environment.EnvironmentProvider;

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/logger/MetricsLogger.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/logger/MetricsLogger.java
@@ -276,7 +276,6 @@ public class MetricsLogger {
         try {
             defaultDimension.addDimension(dimKey, dimVal);
         } catch (InvalidDimensionException | DimensionSetExceededException e) {
-            // just do nothing
         }
     }
 

--- a/src/test/java/software/amazon/cloudwatchlogs/emf/logger/MetricsLoggerTest.java
+++ b/src/test/java/software/amazon/cloudwatchlogs/emf/logger/MetricsLoggerTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.*;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -82,6 +83,18 @@ class MetricsLoggerTest {
         assertEquals(
                 dimensionValue,
                 sink.getContext().getDimensions().get(0).getDimensionValue(dimensionName));
+    }
+
+    @Test
+    void whenDefaultDimension_DimensionValue_Null() throws InvalidDimensionException, DimensionSetExceededException{
+        when(environment.getLogGroupName()).thenReturn("");
+        logger.flush();
+
+        assertEquals(1, sink.getContext().getDimensions().size());
+        Set<String> dimensionKeys = sink.getContext().getDimensions().get(0).getDimensionKeys();
+        assertEquals(2, dimensionKeys.size());
+        dimensionKeys.contains("ServiceName");
+        dimensionKeys.contains("ServiceType");
     }
 
     @ParameterizedTest

--- a/src/test/java/software/amazon/cloudwatchlogs/emf/logger/MetricsLoggerTest.java
+++ b/src/test/java/software/amazon/cloudwatchlogs/emf/logger/MetricsLoggerTest.java
@@ -86,7 +86,7 @@ class MetricsLoggerTest {
     }
 
     @Test
-    void whenDefaultDimension_DimensionValue_Null() throws InvalidDimensionException, DimensionSetExceededException{
+    void whenDefaultDimension_DimensionValue_Empty() throws DimensionSetExceededException{
         when(environment.getLogGroupName()).thenReturn("");
         logger.flush();
 

--- a/src/test/java/software/amazon/cloudwatchlogs/emf/logger/MetricsLoggerTest.java
+++ b/src/test/java/software/amazon/cloudwatchlogs/emf/logger/MetricsLoggerTest.java
@@ -86,8 +86,20 @@ class MetricsLoggerTest {
     }
 
     @Test
-    void whenDefaultDimension_DimensionValue_Empty() throws DimensionSetExceededException{
+    void whenDefaultDimension_DimensionValue_Empty() throws DimensionSetExceededException {
         when(environment.getLogGroupName()).thenReturn("");
+        logger.flush();
+
+        assertEquals(1, sink.getContext().getDimensions().size());
+        Set<String> dimensionKeys = sink.getContext().getDimensions().get(0).getDimensionKeys();
+        assertEquals(2, dimensionKeys.size());
+        dimensionKeys.contains("ServiceName");
+        dimensionKeys.contains("ServiceType");
+    }
+
+    @Test
+    void whenDefaultDimension_DimensionValue_Blank() throws DimensionSetExceededException {
+        when(environment.getLogGroupName()).thenReturn(" ");
         logger.flush();
 
         assertEquals(1, sink.getContext().getDimensions().size());


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/aws-embedded-metrics-java/issues/125

*Description of changes:*
Customer with ECS FireLens now has problem to flush metrics logger when using default dimension because we return "" for log group name but we throw InvalidDimensionException when setting the empty dimension. Example stack trace

```
software.amazon.cloudwatchlogs.emf.exception.InvalidDimensionException: Dimension value cannot be empty
at software.amazon.cloudwatchlogs.emf.util.Validator.validateDimensionSet(Validator.java:48)
at software.amazon.cloudwatchlogs.emf.model.DimensionSet.addDimension(DimensionSet.java:167)
at software.amazon.cloudwatchlogs.emf.logger.MetricsLogger.configureContextForEnvironment(MetricsLogger.java:268)
at software.amazon.cloudwatchlogs.emf.logger.MetricsLogger.flush(MetricsLogger.java:91)
at com.amazonaws.toledo.telemetry.common.util.MetricsPublisher.flush(MetricsPublisher.java:39)
at com.amazonaws.toledo.telemetry.streamprocessor.StreamProcessor.processRecords(StreamProcessor.java:147)
at com.amazonaws.services.kinesis.clientlibrary.lib.worker.ProcessTask.callProcessRecords(ProcessTask.java:221)
at com.amazonaws.services.kinesis.clientlibrary.lib.worker.ProcessTask.call(ProcessTask.java:176)
at com.amazonaws.services.kinesis.clientlibrary.lib.worker.MetricsCollectingTaskDecorator.call(MetricsCollectingTaskDecorator.java:49)
at com.amazonaws.services.kinesis.clientlibrary.lib.worker.MetricsCollectingTaskDecorator.call(MetricsCollectingTaskDecorator.java:24)
at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
at java.base/java.lang.Thread.run(Thread.java:829)
```

This change is to skip adding dimension if dimension value is null or empty

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
