### PR TITLE
Fix: Context copying is disabling default dimensions

### DIFF
--- a/examples/agent/src/main/java/agent/App.java
+++ b/examples/agent/src/main/java/agent/App.java
@@ -23,7 +23,11 @@ public class App {
         } catch (InvalidMetricException | InvalidDimensionException | DimensionSetExceededException e) {
             System.out.println(e);
         }
-        environment.getSink().shutdown().orTimeout(360_000L, TimeUnit.MILLISECONDS);
+
+        try {
+            environment.getSink().shutdown().get(360_000L, TimeUnit.MILLISECONDS);
+        } catch (Exception ignored) {
+        }
     }
 
     private static void emitMetric(Environment environment)

--- a/examples/ecs-firelens/src/main/java/App.java
+++ b/examples/ecs-firelens/src/main/java/App.java
@@ -51,7 +51,10 @@ public class App {
     private static void registerShutdownHook() {
         // https://aws.amazon.com/blogs/containers/graceful-shutdowns-with-ecs/
         Signal.handle(new Signal("TERM"), sig -> {
-            env.getSink().shutdown().orTimeout(1_000L, TimeUnit.MILLISECONDS);
+            try {
+                env.getSink().shutdown().get(1_000L, TimeUnit.MILLISECONDS);
+            } catch (Exception ignored) {
+            }
             System.exit(0);
         });
     }

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/environment/AgentBasedEnvironment.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/environment/AgentBasedEnvironment.java
@@ -16,6 +16,7 @@
 
 package software.amazon.cloudwatchlogs.emf.environment;
 
+import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import software.amazon.cloudwatchlogs.emf.Constants;
 import software.amazon.cloudwatchlogs.emf.config.Configuration;
@@ -36,11 +37,14 @@ public abstract class AgentBasedEnvironment implements Environment {
 
     @Override
     public String getName() {
-        if (config.getServiceName().isEmpty()) {
-            log.warn("Unknown ServiceName.");
-            return Constants.UNKNOWN;
+        Optional<String> serviceName = config.getServiceName();
+
+        if (serviceName.isPresent()) {
+            return serviceName.get();
         }
-        return config.getServiceName().get();
+
+        log.warn("Unknown ServiceName.");
+        return Constants.UNKNOWN;
     }
 
     @Override
@@ -64,13 +68,13 @@ public abstract class AgentBasedEnvironment implements Environment {
     public ISink getSink() {
         if (sink == null) {
             Endpoint endpoint;
-            if (config.getAgentEndpoint().isEmpty()) {
+            if (config.getAgentEndpoint().isPresent()) {
+                endpoint = Endpoint.fromURL(config.getAgentEndpoint().get());
+            } else {
                 log.info(
                         "Endpoint is not defined. Using default: {}",
                         Endpoint.DEFAULT_TCP_ENDPOINT);
                 endpoint = Endpoint.DEFAULT_TCP_ENDPOINT;
-            } else {
-                endpoint = Endpoint.fromURL(config.getAgentEndpoint().get());
             }
             sink =
                     new AgentSink(

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/environment/DefaultEnvironment.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/environment/DefaultEnvironment.java
@@ -16,6 +16,7 @@
 
 package software.amazon.cloudwatchlogs.emf.environment;
 
+import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import software.amazon.cloudwatchlogs.emf.Constants;
 import software.amazon.cloudwatchlogs.emf.config.Configuration;
@@ -37,11 +38,14 @@ public class DefaultEnvironment extends AgentBasedEnvironment {
 
     @Override
     public String getType() {
-        if (config.getServiceType().isEmpty()) {
-            log.info("Unknown ServiceType");
-            return Constants.UNKNOWN;
+        Optional<String> serviceType = config.getServiceType();
+
+        if (serviceType.isPresent()) {
+            return serviceType.get();
         }
-        return config.getServiceType().get();
+
+        log.info("Unknown ServiceType");
+        return Constants.UNKNOWN;
     }
 
     @Override

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/model/MetricDirective.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/model/MetricDirective.java
@@ -168,7 +168,7 @@ class MetricDirective {
         metricDirective.shouldUseDefaultDimension = this.shouldUseDefaultDimension;
 
         if (preserveDimensions) {
-            metricDirective.setDimensions(this.dimensions);
+            this.dimensions.forEach(metricDirective::putDimensionSet);
         }
 
         return metricDirective;

--- a/src/test/java/software/amazon/cloudwatchlogs/emf/logger/MetricsLoggerTest.java
+++ b/src/test/java/software/amazon/cloudwatchlogs/emf/logger/MetricsLoggerTest.java
@@ -483,7 +483,7 @@ class MetricsLoggerTest {
     @Test
     void flush_doesNotPreserveMetrics()
             throws InvalidMetricException, InvalidDimensionException,
-            DimensionSetExceededException {
+                    DimensionSetExceededException {
         MetricsLogger logger = new MetricsLogger(envProvider);
         logger.setDimensions(DimensionSet.of("Name", "Test"));
         logger.putMetric("Count", 1.0);

--- a/src/test/java/software/amazon/cloudwatchlogs/emf/logger/MetricsLoggerTest.java
+++ b/src/test/java/software/amazon/cloudwatchlogs/emf/logger/MetricsLoggerTest.java
@@ -276,6 +276,19 @@ class MetricsLoggerTest {
     }
 
     @Test
+    void whenMultipleFlush_withNoDimensionsChanges_keepDefaultDimensions()
+            throws InvalidMetricException, DimensionSetExceededException {
+        logger.putMetric("Count", 1);
+
+        logger.flush();
+        logger.flush();
+
+        expectDimension("LogGroup", "test-log-group");
+        expectDimension("ServiceName", "test-env-name");
+        expectDimension("ServiceType", "test-env-type");
+    }
+
+    @Test
     void setDimensions_clearsAllDimensions() throws DimensionSetExceededException {
         MetricsLogger logger = new MetricsLogger(envProvider);
 

--- a/src/test/java/software/amazon/cloudwatchlogs/emf/logger/MetricsLoggerTest.java
+++ b/src/test/java/software/amazon/cloudwatchlogs/emf/logger/MetricsLoggerTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import java.time.Instant;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -126,9 +127,11 @@ class MetricsLoggerTest {
 
     @Test
     void whenSetDimension_withNameTooLong_thenThrowDimensionException() {
-        String dimensionName =
-                new String(new char[Constants.MAX_DIMENSION_NAME_LENGTH + 1]).replace("\0", "a");
+        char[] longName = new char[Constants.MAX_DIMENSION_NAME_LENGTH + 1];
+        Arrays.fill(longName, 'a');
+        String dimensionName = String.valueOf(longName);
         String dimensionValue = "dimValue";
+
         assertThrows(
                 InvalidDimensionException.class,
                 () -> DimensionSet.of(dimensionName, dimensionValue));
@@ -137,8 +140,10 @@ class MetricsLoggerTest {
     @Test
     void whenSetDimension_withValueTooLong_thenThrowDimensionException() {
         String dimensionName = "dim";
-        String dimensionValue =
-                new String(new char[Constants.MAX_DIMENSION_VALUE_LENGTH + 1]).replace("\0", "a");
+        char[] longName = new char[Constants.MAX_DIMENSION_VALUE_LENGTH + 1];
+        Arrays.fill(longName, 'a');
+        String dimensionValue = String.valueOf(longName);
+
         assertThrows(
                 InvalidDimensionException.class,
                 () -> DimensionSet.of(dimensionName, dimensionValue));
@@ -317,8 +322,10 @@ class MetricsLoggerTest {
 
     @Test
     void whenPutMetric_withTooLongName_thenThrowInvalidMetricException() {
-        String name1 =
-                new String(new char[Constants.MAX_METRIC_NAME_LENGTH + 1]).replace("\0", "a");
+        char[] longName = new char[Constants.MAX_METRIC_NAME_LENGTH + 1];
+        Arrays.fill(longName, 'a');
+        String name1 = new String(longName);
+
         assertThrows(InvalidMetricException.class, () -> logger.putMetric(name1, 1));
     }
 
@@ -365,8 +372,10 @@ class MetricsLoggerTest {
 
     @Test
     void whenSetNamespace_withNameTooLong_thenThrowInvalidNamespaceException() {
-        String namespace =
-                new String(new char[Constants.MAX_NAMESPACE_LENGTH + 1]).replace("\0", "a");
+        char[] longName = new char[Constants.MAX_NAMESPACE_LENGTH + 1];
+        Arrays.fill(longName, 'a');
+        String namespace = new String(longName);
+
         assertThrows(InvalidNamespaceException.class, () -> logger.setNamespace(namespace));
     }
 

--- a/src/test/java/software/amazon/cloudwatchlogs/emf/logger/MetricsLoggerTest.java
+++ b/src/test/java/software/amazon/cloudwatchlogs/emf/logger/MetricsLoggerTest.java
@@ -93,8 +93,8 @@ class MetricsLoggerTest {
         assertEquals(1, sink.getContext().getDimensions().size());
         Set<String> dimensionKeys = sink.getContext().getDimensions().get(0).getDimensionKeys();
         assertEquals(2, dimensionKeys.size());
-        dimensionKeys.contains("ServiceName");
-        dimensionKeys.contains("ServiceType");
+        assertTrue(dimensionKeys.contains("ServiceName"));
+        assertTrue(dimensionKeys.contains("ServiceType"));
     }
 
     @Test
@@ -105,8 +105,8 @@ class MetricsLoggerTest {
         assertEquals(1, sink.getContext().getDimensions().size());
         Set<String> dimensionKeys = sink.getContext().getDimensions().get(0).getDimensionKeys();
         assertEquals(2, dimensionKeys.size());
-        dimensionKeys.contains("ServiceName");
-        dimensionKeys.contains("ServiceType");
+        assertTrue(dimensionKeys.contains("ServiceName"));
+        assertTrue(dimensionKeys.contains("ServiceType"));
     }
 
     @ParameterizedTest

--- a/src/test/java/software/amazon/cloudwatchlogs/emf/logger/MetricsLoggerTest.java
+++ b/src/test/java/software/amazon/cloudwatchlogs/emf/logger/MetricsLoggerTest.java
@@ -126,7 +126,8 @@ class MetricsLoggerTest {
 
     @Test
     void whenSetDimension_withNameTooLong_thenThrowDimensionException() {
-        String dimensionName = "a".repeat(Constants.MAX_DIMENSION_NAME_LENGTH + 1);
+        String dimensionName =
+                new String(new char[Constants.MAX_DIMENSION_NAME_LENGTH + 1]).replace("\0", "a");
         String dimensionValue = "dimValue";
         assertThrows(
                 InvalidDimensionException.class,
@@ -136,7 +137,8 @@ class MetricsLoggerTest {
     @Test
     void whenSetDimension_withValueTooLong_thenThrowDimensionException() {
         String dimensionName = "dim";
-        String dimensionValue = "a".repeat(Constants.MAX_DIMENSION_VALUE_LENGTH + 1);
+        String dimensionValue =
+                new String(new char[Constants.MAX_DIMENSION_VALUE_LENGTH + 1]).replace("\0", "a");
         assertThrows(
                 InvalidDimensionException.class,
                 () -> DimensionSet.of(dimensionName, dimensionValue));
@@ -315,7 +317,8 @@ class MetricsLoggerTest {
 
     @Test
     void whenPutMetric_withTooLongName_thenThrowInvalidMetricException() {
-        String name1 = "a".repeat(Constants.MAX_METRIC_NAME_LENGTH + 1);
+        String name1 =
+                new String(new char[Constants.MAX_METRIC_NAME_LENGTH + 1]).replace("\0", "a");
         assertThrows(InvalidMetricException.class, () -> logger.putMetric(name1, 1));
     }
 
@@ -362,7 +365,8 @@ class MetricsLoggerTest {
 
     @Test
     void whenSetNamespace_withNameTooLong_thenThrowInvalidNamespaceException() {
-        String namespace = "a".repeat(Constants.MAX_NAMESPACE_LENGTH + 1);
+        String namespace =
+                new String(new char[Constants.MAX_NAMESPACE_LENGTH + 1]).replace("\0", "a");
         assertThrows(InvalidNamespaceException.class, () -> logger.setNamespace(namespace));
     }
 
@@ -479,7 +483,7 @@ class MetricsLoggerTest {
     @Test
     void flush_doesNotPreserveMetrics()
             throws InvalidMetricException, InvalidDimensionException,
-                    DimensionSetExceededException {
+            DimensionSetExceededException {
         MetricsLogger logger = new MetricsLogger(envProvider);
         logger.setDimensions(DimensionSet.of("Name", "Test"));
         logger.putMetric("Count", 1.0);

--- a/src/test/java/software/amazon/cloudwatchlogs/emf/model/MetricDefinitionTest.java
+++ b/src/test/java/software/amazon/cloudwatchlogs/emf/model/MetricDefinitionTest.java
@@ -20,7 +20,8 @@ import static org.junit.Assert.assertEquals;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.util.List;
+import java.util.Arrays;
+import java.util.Collections;
 import org.junit.Test;
 
 public class MetricDefinitionTest {
@@ -51,9 +52,9 @@ public class MetricDefinitionTest {
     @Test
     public void testAddValue() {
         MetricDefinition md = new MetricDefinition("Time", Unit.MICROSECONDS, 10);
-        assertEquals(List.of(10d), md.getValues());
+        assertEquals(Collections.singletonList(10d), md.getValues());
 
         md.addValue(20);
-        assertEquals(List.of(10d, 20d), md.getValues());
+        assertEquals(Arrays.asList(10d, 20d), md.getValues());
     }
 }

--- a/src/test/java/software/amazon/cloudwatchlogs/emf/model/MetricsContextTest.java
+++ b/src/test/java/software/amazon/cloudwatchlogs/emf/model/MetricsContextTest.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Assertions;
@@ -101,7 +102,7 @@ class MetricsContextTest {
             expectedValues.add((double) i);
         }
         Assertions.assertEquals(expectedValues, allMetrics.get(0).getValues());
-        Assertions.assertEquals(List.of(100.0), allMetrics.get(1).getValues());
+        Assertions.assertEquals(Collections.singletonList(100.0), allMetrics.get(1).getValues());
     }
 
     @Test
@@ -128,10 +129,12 @@ class MetricsContextTest {
             expectedValues.add((double) i);
         }
         Assertions.assertEquals(expectedValues, metricsFromEvent1.get(0).getValues());
-        Assertions.assertEquals(List.of(2.0), metricsFromEvent1.get(1).getValues());
+        Assertions.assertEquals(
+                Collections.singletonList(2.0), metricsFromEvent1.get(1).getValues());
 
         Assertions.assertEquals(1, metricsFromEvent2.size());
-        Assertions.assertEquals(List.of(100.0), metricsFromEvent2.get(0).getValues());
+        Assertions.assertEquals(
+                Collections.singletonList(100.0), metricsFromEvent2.get(0).getValues());
     }
 
     @Test

--- a/src/test/java/software/amazon/cloudwatchlogs/emf/model/RootNodeTest.java
+++ b/src/test/java/software/amazon/cloudwatchlogs/emf/model/RootNodeTest.java
@@ -19,6 +19,7 @@ package software.amazon.cloudwatchlogs.emf.model;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Assertions;
@@ -72,7 +73,8 @@ class RootNodeTest {
 
         mc.putProperty("Prop1", "PropValue1");
 
-        Assertions.assertEquals(List.of(10.0, 20.0), rootNode.getTargetMembers().get("Count"));
+        Assertions.assertEquals(
+                Arrays.asList(10.0, 20.0), rootNode.getTargetMembers().get("Count"));
         Assertions.assertEquals(100.0, rootNode.getTargetMembers().get("Latency"));
         Assertions.assertEquals("DimVal1", rootNode.getTargetMembers().get("Dim1"));
         Assertions.assertEquals("PropValue1", rootNode.getTargetMembers().get("Prop1"));

--- a/src/test/java/software/amazon/cloudwatchlogs/emf/sinks/AgentSinkTest.java
+++ b/src/test/java/software/amazon/cloudwatchlogs/emf/sinks/AgentSinkTest.java
@@ -103,7 +103,8 @@ public class AgentSinkTest {
         ObjectMapper objectMapper = new ObjectMapper();
         Map<String, Object> emf_map =
                 objectMapper.readValue(
-                        fixture.client.getMessages().get(0), new TypeReference<>() {});
+                        fixture.client.getMessages().get(0),
+                        new TypeReference<Map<String, Object>>() {});
         Map<String, Object> metadata = (Map<String, Object>) emf_map.get("_aws");
 
         assertFalse(metadata.containsKey("LogGroupName"));

--- a/src/test/java/software/amazon/cloudwatchlogs/emf/sinks/MultiSinkTest.java
+++ b/src/test/java/software/amazon/cloudwatchlogs/emf/sinks/MultiSinkTest.java
@@ -28,8 +28,8 @@ public class MultiSinkTest {
     @Test
     public void shutdownCompletesExceptionallyIfComponentSinkCompletesExceptionally() {
         // arrange
-        CompletableFuture<Void> failedResult =
-                CompletableFuture.failedFuture(new RuntimeException());
+        CompletableFuture<Void> failedResult = new CompletableFuture<>();
+        failedResult.completeExceptionally(new RuntimeException());
         TestSink sink1 = new TestSink();
         TestSink sink2 = new TestSink(failedResult);
         MultiSink multiSink = MultiSink.builder().sink(sink1).sink(sink2).build();


### PR DESCRIPTION
*Issue #, if available:* #127

*Description of changes:*
- Changes context copy to use `putDimensions` instead of `setDimensions`
- Fixes for java downgrade in #124 
- Small bug fix from #126 
- Changed buildspec `runtime-versions` from `corretto11` to `corretto8`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
