### PR TITLE
High Resolution Metrics Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ class Example {
 		try {
 			metrics.putDimensions(DimensionSet.of("Service", "Aggregator"));
 			metrics.putMetric("ProcessingLatency", 100, Unit.MILLISECONDS, StorageResolution.STANDARD);
+			metrics.putMetric("Memory.HeapUsed", 1600424.0, Unit.BYTES, StorageResolution.HIGH);
 		} catch (InvalidDimensionException | InvalidMetricException e) {
 			log.error(e);
 		}
@@ -101,10 +102,18 @@ Requirements:
 - Values must be in the range of 8.515920e-109 to 1.174271e+108. In addition, special values (for example, NaN, +Infinity, -Infinity) are not supported.
 - Metrics must meet CloudWatch Metrics requirements, otherwise a `InvalidMetricException` will be thrown. See [MetricDatum](https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_MetricDatum.html) for valid values.
 
+- ##### Storage Resolution
+An OPTIONAL value representing the storage resolution for the corresponding metric. Setting this to `High` specifies this metric as a high-resolution metric, so that CloudWatch stores the metric with sub-minute resolution down to one second. Setting this to `Standard` specifies this metric as a standard-resolution metric, which CloudWatch stores at 1-minute resolution. If a value is not provided, then a default value of `Standard` is assumed. See [Cloud Watch High-Resolution metrics](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/publishingMetrics.html#high-resolution-metrics)
+
 Examples:
 
 ```java
-putMetric("Latency", 200, Unit.MILLISECONDS, StorageResolution.STANDARD)
+// Standard Resolution example
+putMetric("Latency", 200, Unit.MILLISECONDS)
+putMetric("Latency", 201, Unit.MILLISECONDS, StorageResolution.STANDARD)
+		
+// High Resolution example
+putMetric("Memory.HeapUsed", 1600424.0, Unit.BYTES, StorageResolution.HIGH);
 ```
 
 - MetricsLogger **putProperty**(String key, Object value )

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Examples:
 // Standard Resolution example
 putMetric("Latency", 200, Unit.MILLISECONDS)
 putMetric("Latency", 201, Unit.MILLISECONDS, StorageResolution.STANDARD)
-		
+
 // High Resolution example
 putMetric("Memory.HeapUsed", 1600424.0, Unit.BYTES, StorageResolution.HIGH);
 ```

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ The `MetricsLogger` is the interface you will use to publish embedded metrics.
 - MetricsLogger **putMetric**(String key, double value, Unit unit)
 - MetricsLogger **putMetric**(String key, double value)
 
-Adds a new metric to the current logger context. Multiple metrics using the same key will be appended to an array of values. Multiple metrics cannot have same key but different storage resolution. The Embedded Metric Format supports a maximum of 100 values per key.
+Adds a new metric to the current logger context. Multiple metrics using the same key will be appended to an array of values. Multiple metrics cannot have same key and different storage resolution. The Embedded Metric Format supports a maximum of 100 values per key.
 
 Requirements:
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ The `MetricsLogger` is the interface you will use to publish embedded metrics.
 - MetricsLogger **putMetric**(String key, double value, Unit unit)
 - MetricsLogger **putMetric**(String key, double value)
 
-Adds a new metric to the current logger context. Multiple metrics using the same key will be appended to an array of values. Multiple metrics cannot have same key and different storage resolution. The Embedded Metric Format supports a maximum of 100 values per key.
+Adds a new metric to the current logger context. Multiple metrics using the same key will be appended to an array of values. Multiple metrics cannot have the same key and different storage resolutions. The Embedded Metric Format supports a maximum of 100 values per key.
 
 Requirements:
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ class Example {
 
 		try {
 			metrics.putDimensions(DimensionSet.of("Service", "Aggregator"));
-			metrics.putMetric("ProcessingLatency", 100, Unit.MILLISECONDS);
+			metrics.putMetric("ProcessingLatency", 100, Unit.MILLISECONDS, StorageResolution.STANDARD);
 		} catch (InvalidDimensionException | InvalidMetricException e) {
 			log.error(e);
 		}
@@ -87,10 +87,12 @@ environment.getSink().shutdown().orTimeout(10_000L, TimeUnit.MILLISECONDS);
 
 The `MetricsLogger` is the interface you will use to publish embedded metrics.
 
+- MetricsLogger **putMetric**(String key, double value, Unit unit, StorageResolution storageResolution)
+- MetricsLogger **putMetric**(String key, double value, StorageResolution storageResolution)
 - MetricsLogger **putMetric**(String key, double value, Unit unit)
 - MetricsLogger **putMetric**(String key, double value)
 
-Adds a new metric to the current logger context. Multiple metrics using the same key will be appended to an array of values. The Embedded Metric Format supports a maximum of 100 values per key.
+Adds a new metric to the current logger context. Multiple metrics using the same key will be appended to an array of values. Multiple metrics cannot have same key but different storage resolution. The Embedded Metric Format supports a maximum of 100 values per key.
 
 Requirements:
 
@@ -102,7 +104,7 @@ Requirements:
 Examples:
 
 ```java
-putMetric("Latency", 200, Unit.MILLISECONDS)
+putMetric("Latency", 200, Unit.MILLISECONDS, StorageResolution.STANDARD)
 ```
 
 - MetricsLogger **putProperty**(String key, Object value )

--- a/canarytests/agent/src/main/java/emf/canary/ECSRunnable.java
+++ b/canarytests/agent/src/main/java/emf/canary/ECSRunnable.java
@@ -8,6 +8,7 @@ import software.amazon.cloudwatchlogs.emf.exception.InvalidMetricException;
 import software.amazon.cloudwatchlogs.emf.exception.InvalidNamespaceException;
 import software.amazon.cloudwatchlogs.emf.logger.MetricsLogger;
 import software.amazon.cloudwatchlogs.emf.model.DimensionSet;
+import software.amazon.cloudwatchlogs.emf.model.StorageResolution;
 import software.amazon.cloudwatchlogs.emf.model.Unit;
 
 import java.lang.management.ManagementFactory;
@@ -46,7 +47,7 @@ public class ECSRunnable implements Runnable {
         try {
             logger.putMetric("Invoke", 1, Unit.COUNT);
             logger.putMetric("Memory.HeapTotal", heapTotal, Unit.COUNT);
-            logger.putMetric("Memory.HeapUsed", heapUsed, Unit.COUNT);
+            logger.putMetric("Memory.HeapUsed", heapUsed, Unit.COUNT, StorageResolution.HIGH);
             logger.putMetric("Memory.JVMUsedTotal", heapUsed + nonHeapUsed, Unit.COUNT);
         } catch (InvalidMetricException e) {
             System.out.println(e);

--- a/examples/agent/src/main/java/agent/App.java
+++ b/examples/agent/src/main/java/agent/App.java
@@ -9,6 +9,7 @@ import software.amazon.cloudwatchlogs.emf.exception.InvalidMetricException;
 import software.amazon.cloudwatchlogs.emf.logger.MetricsLogger;
 import software.amazon.cloudwatchlogs.emf.model.DimensionSet;
 import software.amazon.cloudwatchlogs.emf.model.Unit;
+import software.amazon.cloudwatchlogs.emf.model.StorageResolution;
 
 import java.util.concurrent.TimeUnit;
 
@@ -35,6 +36,7 @@ public class App {
         MetricsLogger logger = new MetricsLogger(environment);
         logger.setDimensions(DimensionSet.of("Operation", "Agent"));
         logger.putMetric("ExampleMetric", 100, Unit.MILLISECONDS);
+        logger.putMetric("ExampleHighResolutionMetric", 10, Unit.MILLISECONDS, StorageResolution.HIGH);
         logger.putProperty("RequestId", "422b1569-16f6-4a03-b8f0-fe3fd9b100f8");
         logger.flush();
     }

--- a/examples/ecs-firelens/src/main/java/App.java
+++ b/examples/ecs-firelens/src/main/java/App.java
@@ -23,6 +23,7 @@ import software.amazon.cloudwatchlogs.emf.environment.Environment;
 import software.amazon.cloudwatchlogs.emf.environment.EnvironmentProvider;
 import software.amazon.cloudwatchlogs.emf.exception.InvalidMetricException;
 import software.amazon.cloudwatchlogs.emf.logger.MetricsLogger;
+import software.amazon.cloudwatchlogs.emf.model.StorageResolution;
 import software.amazon.cloudwatchlogs.emf.model.Unit;
 import sun.misc.Signal;
 import java.io.IOException;
@@ -39,6 +40,7 @@ public class App {
         MetricsLogger logger = new MetricsLogger();
         logger.setNamespace("FargateEMF");
         logger.putMetric("Latency", 63, Unit.MILLISECONDS);
+        logger.putMetric("LatencyInHighResolution", 65, Unit.MILLISECONDS, StorageResolution.HIGH);
         logger.flush();
         HttpServer server = HttpServer.create(new InetSocketAddress(8000), 0);
         int portNumber = 8000;
@@ -75,6 +77,7 @@ public class App {
             logger.putProperty("Url", he.getRequestURI());
             try {
                 logger.putMetric("ProcessingTime", System.currentTimeMillis() - time, Unit.MILLISECONDS);
+                logger.putMetric("ProcessingTimeInHighResolution", System.currentTimeMillis() - time, Unit.MILLISECONDS, StorageResolution.HIGH);
             } catch (InvalidMetricException e) {
                 System.out.println(e);
             }

--- a/examples/ecs-firelens/src/main/java/App.java
+++ b/examples/ecs-firelens/src/main/java/App.java
@@ -40,7 +40,7 @@ public class App {
         MetricsLogger logger = new MetricsLogger();
         logger.setNamespace("FargateEMF");
         logger.putMetric("Latency", 63, Unit.MILLISECONDS);
-        logger.putMetric("LatencyInHighResolution", 65, Unit.MILLISECONDS, StorageResolution.HIGH);
+        logger.putMetric("CPU Utilization", 87, Unit.PERCENT, StorageResolution.HIGH);
         logger.flush();
         HttpServer server = HttpServer.create(new InetSocketAddress(8000), 0);
         int portNumber = 8000;
@@ -77,7 +77,6 @@ public class App {
             logger.putProperty("Url", he.getRequestURI());
             try {
                 logger.putMetric("ProcessingTime", System.currentTimeMillis() - time, Unit.MILLISECONDS);
-                logger.putMetric("ProcessingTimeInHighResolution", System.currentTimeMillis() - time, Unit.MILLISECONDS, StorageResolution.HIGH);
             } catch (InvalidMetricException e) {
                 System.out.println(e);
             }

--- a/examples/lambda/src/main/java/Handler.java
+++ b/examples/lambda/src/main/java/Handler.java
@@ -21,7 +21,7 @@ public class Handler implements RequestHandler<Map<String, String>, String> {
         try {
             logger.putDimensions(DimensionSet.of("Service", "Aggregator"));
             logger.putMetric("ProcessingLatency", 100, Unit.MILLISECONDS);
-            logger.putMetric("ProcessingLatencyInHighResolution", 101, Unit.MILLISECONDS, StorageResolution.HIGH);
+            logger.putMetric("CPU Utilization", 87, Unit.PERCENT, StorageResolution.HIGH);
         } catch (InvalidDimensionException | InvalidMetricException | DimensionSetExceededException e) {
             System.out.println(e);
         }

--- a/examples/lambda/src/main/java/Handler.java
+++ b/examples/lambda/src/main/java/Handler.java
@@ -5,6 +5,7 @@ import software.amazon.cloudwatchlogs.emf.exception.InvalidDimensionException;
 import software.amazon.cloudwatchlogs.emf.exception.InvalidMetricException;
 import software.amazon.cloudwatchlogs.emf.logger.MetricsLogger;
 import software.amazon.cloudwatchlogs.emf.model.DimensionSet;
+import software.amazon.cloudwatchlogs.emf.model.StorageResolution;
 import software.amazon.cloudwatchlogs.emf.model.Unit;
 
 import java.util.HashMap;
@@ -20,6 +21,7 @@ public class Handler implements RequestHandler<Map<String, String>, String> {
         try {
             logger.putDimensions(DimensionSet.of("Service", "Aggregator"));
             logger.putMetric("ProcessingLatency", 100, Unit.MILLISECONDS);
+            logger.putMetric("ProcessingLatencyInHighResolution", 101, Unit.MILLISECONDS, StorageResolution.HIGH);
         } catch (InvalidDimensionException | InvalidMetricException | DimensionSetExceededException e) {
             System.out.println(e);
         }

--- a/src/integration-test/java/software/amazon/cloudwatchlogs/emf/MetricsLoggerIntegrationTest.java
+++ b/src/integration-test/java/software/amazon/cloudwatchlogs/emf/MetricsLoggerIntegrationTest.java
@@ -38,6 +38,7 @@ import software.amazon.cloudwatchlogs.emf.exception.InvalidDimensionException;
 import software.amazon.cloudwatchlogs.emf.exception.InvalidMetricException;
 import software.amazon.cloudwatchlogs.emf.logger.MetricsLogger;
 import software.amazon.cloudwatchlogs.emf.model.DimensionSet;
+import software.amazon.cloudwatchlogs.emf.model.StorageResolution;
 import software.amazon.cloudwatchlogs.emf.model.Unit;
 
 public class MetricsLoggerIntegrationTest {
@@ -122,7 +123,7 @@ public class MetricsLoggerIntegrationTest {
     private void logMetric(Environment env, String metricName) throws InvalidMetricException {
         MetricsLogger logger = new MetricsLogger(env);
         logger.putDimensions(dimensions);
-        logger.putMetric(metricName, 100, Unit.MILLISECONDS);
+        logger.putMetric(metricName, 100, Unit.MILLISECONDS, StorageResolution.HIGH);
         logger.flush();
     }
 

--- a/src/integration-test/java/software/amazon/cloudwatchlogs/emf/MetricsLoggerIntegrationTest.java
+++ b/src/integration-test/java/software/amazon/cloudwatchlogs/emf/MetricsLoggerIntegrationTest.java
@@ -148,7 +148,7 @@ public class MetricsLoggerIntegrationTest {
                 .namespace("aws-embedded-metrics")
                 .metricName(metricName)
                 .dimensions(dims)
-                .period(60)
+                .period(1)
                 .startTime(now.minusMillis(5000))
                 .endTime(now)
                 .statistics(Statistic.SAMPLE_COUNT)

--- a/src/integration-test/java/software/amazon/cloudwatchlogs/emf/MetricsLoggerIntegrationTest.java
+++ b/src/integration-test/java/software/amazon/cloudwatchlogs/emf/MetricsLoggerIntegrationTest.java
@@ -148,7 +148,7 @@ public class MetricsLoggerIntegrationTest {
                 .namespace("aws-embedded-metrics")
                 .metricName(metricName)
                 .dimensions(dims)
-                .period(1)
+                .period(60)
                 .startTime(now.minusMillis(5000))
                 .endTime(now)
                 .statistics(Statistic.SAMPLE_COUNT)

--- a/src/integration-test/java/software/amazon/cloudwatchlogs/emf/MetricsLoggerIntegrationTest.java
+++ b/src/integration-test/java/software/amazon/cloudwatchlogs/emf/MetricsLoggerIntegrationTest.java
@@ -38,7 +38,6 @@ import software.amazon.cloudwatchlogs.emf.exception.InvalidDimensionException;
 import software.amazon.cloudwatchlogs.emf.exception.InvalidMetricException;
 import software.amazon.cloudwatchlogs.emf.logger.MetricsLogger;
 import software.amazon.cloudwatchlogs.emf.model.DimensionSet;
-import software.amazon.cloudwatchlogs.emf.model.StorageResolution;
 import software.amazon.cloudwatchlogs.emf.model.Unit;
 
 public class MetricsLoggerIntegrationTest {
@@ -123,7 +122,7 @@ public class MetricsLoggerIntegrationTest {
     private void logMetric(Environment env, String metricName) throws InvalidMetricException {
         MetricsLogger logger = new MetricsLogger(env);
         logger.putDimensions(dimensions);
-        logger.putMetric(metricName, 100, Unit.MILLISECONDS, StorageResolution.HIGH);
+        logger.putMetric(metricName, 100, Unit.MILLISECONDS);
         logger.flush();
     }
 

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/logger/MetricsLogger.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/logger/MetricsLogger.java
@@ -35,6 +35,7 @@ import software.amazon.cloudwatchlogs.emf.model.MetricsContext;
 import software.amazon.cloudwatchlogs.emf.model.StorageResolution;
 import software.amazon.cloudwatchlogs.emf.model.Unit;
 import software.amazon.cloudwatchlogs.emf.sinks.ISink;
+import software.amazon.cloudwatchlogs.emf.util.Validator;
 
 /**
  * A metrics logger. Use this interface to publish logs to CloudWatch Logs and extract metrics to
@@ -93,6 +94,7 @@ public class MetricsLogger {
             configureContextForEnvironment(context, environment);
             sink.accept(context);
             context = context.createCopyWithContext(flushPreserveDimensions);
+            Validator.metricNameAndResolutionMap.clear();
         } finally {
             rwl.writeLock().unlock();
         }

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/logger/MetricsLogger.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/logger/MetricsLogger.java
@@ -35,7 +35,6 @@ import software.amazon.cloudwatchlogs.emf.model.MetricsContext;
 import software.amazon.cloudwatchlogs.emf.model.StorageResolution;
 import software.amazon.cloudwatchlogs.emf.model.Unit;
 import software.amazon.cloudwatchlogs.emf.sinks.ISink;
-import software.amazon.cloudwatchlogs.emf.util.Validator;
 
 /**
  * A metrics logger. Use this interface to publish logs to CloudWatch Logs and extract metrics to
@@ -94,7 +93,6 @@ public class MetricsLogger {
             configureContextForEnvironment(context, environment);
             sink.accept(context);
             context = context.createCopyWithContext(flushPreserveDimensions);
-            Validator.metricNameAndResolutionMap.clear();
         } finally {
             rwl.writeLock().unlock();
         }
@@ -193,6 +191,9 @@ public class MetricsLogger {
      * @param value is the value of the metric
      * @param unit is the unit of the metric value
      * @param storageResolution is the resolution of the metric
+     * @see <a
+     *     href="https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/publishingMetrics.html#high-resolution-metrics">CloudWatch
+     *     High Resolution Metrics</a>
      * @return the current logger
      * @throws InvalidMetricException if the metric is invalid
      */
@@ -216,6 +217,9 @@ public class MetricsLogger {
      * @param key is the name of the metric
      * @param value is the value of the metric
      * @param storageResolution is the resolution of the metric
+     * @see <a
+     *     href="https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/publishingMetrics.html#high-resolution-metrics">CloudWatch
+     *     High Resolution Metrics</a>
      * @return the current logger
      * @throws InvalidMetricException if the metric is invalid
      */

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/logger/MetricsLogger.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/logger/MetricsLogger.java
@@ -32,8 +32,8 @@ import software.amazon.cloudwatchlogs.emf.exception.InvalidNamespaceException;
 import software.amazon.cloudwatchlogs.emf.exception.InvalidTimestampException;
 import software.amazon.cloudwatchlogs.emf.model.DimensionSet;
 import software.amazon.cloudwatchlogs.emf.model.MetricsContext;
-import software.amazon.cloudwatchlogs.emf.model.Unit;
 import software.amazon.cloudwatchlogs.emf.model.StorageResolution;
+import software.amazon.cloudwatchlogs.emf.model.Unit;
 import software.amazon.cloudwatchlogs.emf.sinks.ISink;
 
 /**
@@ -194,7 +194,8 @@ public class MetricsLogger {
      * @return the current logger
      * @throws InvalidMetricException if the metric is invalid
      */
-    public MetricsLogger putMetric(String key, double value, Unit unit, StorageResolution storageResolution)
+    public MetricsLogger putMetric(
+            String key, double value, Unit unit, StorageResolution storageResolution)
             throws InvalidMetricException {
         rwl.readLock().lock();
         try {
@@ -204,7 +205,6 @@ public class MetricsLogger {
             rwl.readLock().unlock();
         }
     }
-
 
     /**
      * Put a metric value. This value will be emitted to CloudWatch Metrics asynchronously and does

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/model/MetricDefinition.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/model/MetricDefinition.java
@@ -18,6 +18,7 @@ package software.amazon.cloudwatchlogs.emf.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.util.ArrayList;
@@ -26,8 +27,11 @@ import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NonNull;
+import lombok.Setter;
 import software.amazon.cloudwatchlogs.emf.serializers.UnitDeserializer;
 import software.amazon.cloudwatchlogs.emf.serializers.UnitSerializer;
+import software.amazon.cloudwatchlogs.emf.serializers.StorageResolutionSerializer;
+import software.amazon.cloudwatchlogs.emf.serializers.StorageResolutionFilter;
 
 /** Represents the MetricDefinition of the EMF schema. */
 @AllArgsConstructor
@@ -43,18 +47,33 @@ class MetricDefinition {
     @JsonDeserialize(using = UnitDeserializer.class)
     private Unit unit;
 
+    @Getter
+    @Setter
+    @JsonProperty("StorageResolution")
+    @JsonInclude(value = JsonInclude.Include.CUSTOM, valueFilter = StorageResolutionFilter.class)  //does NOT include in serialization when filter returns true
+    @JsonSerialize(using = StorageResolutionSerializer.class)
+    public StorageResolution storageResolution;
+
     @JsonIgnore @NonNull @Getter private List<Double> values;
 
     MetricDefinition(String name) {
-        this(name, Unit.NONE, new ArrayList<>());
+        this(name, Unit.NONE, StorageResolution.STANDARD, new ArrayList<>());
     }
 
     MetricDefinition(String name, double value) {
-        this(name, Unit.NONE, value);
+        this(name, Unit.NONE, StorageResolution.STANDARD, value);
     }
 
     MetricDefinition(String name, Unit unit, double value) {
-        this(name, unit, new ArrayList<>(Arrays.asList(value)));
+        this(name, unit, StorageResolution.STANDARD, new ArrayList<>(Arrays.asList(value)));
+    }
+
+    MetricDefinition(String name, StorageResolution storageResolution, double value) {
+        this(name, Unit.NONE, storageResolution, new ArrayList<>(Arrays.asList(value)));
+    }
+
+    MetricDefinition(String name, Unit unit, StorageResolution storageResolution, double value) {
+        this(name, unit, storageResolution, new ArrayList<>(Arrays.asList(value)));
     }
 
     void addValue(double value) {

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/model/MetricDefinition.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/model/MetricDefinition.java
@@ -50,7 +50,7 @@ class MetricDefinition {
     @Getter
     @Setter
     @JsonProperty("StorageResolution")
-    @JsonInclude(value = JsonInclude.Include.CUSTOM, valueFilter = StorageResolutionFilter.class)  //does NOT include in serialization when filter returns true
+    @JsonInclude(value = JsonInclude.Include.CUSTOM, valueFilter = StorageResolutionFilter.class)  //Do not serialize when valueFilter is true
     @JsonSerialize(using = StorageResolutionSerializer.class)
     public StorageResolution storageResolution;
 

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/model/MetricDefinition.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/model/MetricDefinition.java
@@ -17,8 +17,8 @@
 package software.amazon.cloudwatchlogs.emf.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.util.ArrayList;
@@ -28,10 +28,10 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.Setter;
+import software.amazon.cloudwatchlogs.emf.serializers.StorageResolutionFilter;
+import software.amazon.cloudwatchlogs.emf.serializers.StorageResolutionSerializer;
 import software.amazon.cloudwatchlogs.emf.serializers.UnitDeserializer;
 import software.amazon.cloudwatchlogs.emf.serializers.UnitSerializer;
-import software.amazon.cloudwatchlogs.emf.serializers.StorageResolutionSerializer;
-import software.amazon.cloudwatchlogs.emf.serializers.StorageResolutionFilter;
 
 /** Represents the MetricDefinition of the EMF schema. */
 @AllArgsConstructor
@@ -50,7 +50,10 @@ class MetricDefinition {
     @Getter
     @Setter
     @JsonProperty("StorageResolution")
-    @JsonInclude(value = JsonInclude.Include.CUSTOM, valueFilter = StorageResolutionFilter.class)  //Do not serialize when valueFilter is true
+    @JsonInclude(
+            value = JsonInclude.Include.CUSTOM,
+            valueFilter =
+                    StorageResolutionFilter.class) // Do not serialize when valueFilter is true
     @JsonSerialize(using = StorageResolutionSerializer.class)
     public StorageResolution storageResolution;
 

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/model/MetricDirective.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/model/MetricDirective.java
@@ -75,14 +75,14 @@ class MetricDirective {
     }
 
     void putMetric(String key, double value, StorageResolution storageResolution) {
-        putMetric(key, value,  Unit.NONE, storageResolution);
+        putMetric(key, value, Unit.NONE, storageResolution);
     }
 
     void putMetric(String key, double value, Unit unit, StorageResolution storageResolution) {
         metrics.compute(
                 key,
                 (k, v) -> {
-                  if (v == null) return new MetricDefinition(key, unit, storageResolution, value);
+                    if (v == null) return new MetricDefinition(key, unit, storageResolution, value);
                     else {
                         v.addValue(value);
                         return v;

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/model/MetricDirective.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/model/MetricDirective.java
@@ -67,14 +67,22 @@ class MetricDirective {
     }
 
     void putMetric(String key, double value) {
-        putMetric(key, value, Unit.NONE);
+        putMetric(key, value, Unit.NONE, StorageResolution.STANDARD);
     }
 
     void putMetric(String key, double value, Unit unit) {
+        putMetric(key, value, unit, StorageResolution.STANDARD);
+    }
+
+    void putMetric(String key, double value, StorageResolution storageResolution) {
+        putMetric(key, value,  Unit.NONE, storageResolution);
+    }
+
+    void putMetric(String key, double value, Unit unit, StorageResolution storageResolution) {
         metrics.compute(
                 key,
                 (k, v) -> {
-                    if (v == null) return new MetricDefinition(key, unit, value);
+                  if (v == null) return new MetricDefinition(key, unit, storageResolution, value);
                     else {
                         v.addValue(value);
                         return v;

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/model/MetricsContext.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/model/MetricsContext.java
@@ -34,7 +34,7 @@ public class MetricsContext {
     @Getter private final RootNode rootNode;
 
     private MetricDirective metricDirective;
-    private final Map<String, String> metricNameAndResolutionMap = new HashMap<>();
+    private final Map<String, StorageResolution> metricNameAndResolutionMap = new HashMap<>();
 
     public MetricsContext() {
         this(new RootNode());

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/model/MetricsContext.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/model/MetricsContext.java
@@ -122,9 +122,7 @@ public class MetricsContext {
             throws InvalidMetricException {
         Validator.validateMetric(key, value, unit, storageResolution, metricNameAndResolutionMap);
         metricDirective.putMetric(key, value, unit, storageResolution);
-        if (!metricNameAndResolutionMap.containsKey(key)) {
-            metricNameAndResolutionMap.put(key, storageResolution);
-        }
+        metricNameAndResolutionMap.put(key, storageResolution);
     }
     /**
      * Add a metric measurement to the context with a storage resolution but without a unit.

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/model/MetricsContext.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/model/MetricsContext.java
@@ -108,6 +108,41 @@ public class MetricsContext {
      * an array of scalar values.
      *
      * <pre>{@code
+     * metricContext.putMetric("Latency", 100, Unit.MILLISECONDS, StorageResolution.HIGH)
+     * }</pre>
+     *
+     * @param key Name of the metric
+     * @param value Value of the metric
+     * @param unit The unit of the metric
+     * @param storageResolution The resolution of the metric
+     * @throws InvalidMetricException if the metric is invalid
+     */
+    public void putMetric(String key, double value, Unit unit, StorageResolution storageResolution) throws InvalidMetricException {
+        Validator.validateMetric(key, value, unit, storageResolution);
+        metricDirective.putMetric(key, value, unit, storageResolution);
+    }
+    /**
+     * Add a metric measurement to the context with a storage resolution but without a unit. Multiple calls using the same key will be stored as
+     * an array of scalar values.
+     *
+     * <pre>{@code
+     * metricContext.putMetric("Latency", 100, StorageResolution.HIGH)
+     * }</pre>
+     *
+     * @param key Name of the metric
+     * @param value Value of the metric
+     * @param storageResolution The resolution of the metric
+     * @throws InvalidMetricException if the metric is invalid
+     */
+    public void putMetric(String key, double value, StorageResolution storageResolution) throws InvalidMetricException {
+        putMetric(key, value, Unit.NONE, storageResolution);
+    }
+
+    /**
+     * Add a metric measurement to the context without a storage resolution. Multiple calls using the same key will be stored as
+     * an array of scalar values.
+     *
+     * <pre>{@code
      * metricContext.putMetric("Latency", 100, Unit.MILLISECONDS)
      * }</pre>
      *
@@ -117,9 +152,8 @@ public class MetricsContext {
      * @throws InvalidMetricException if the metric is invalid
      */
     public void putMetric(String key, double value, Unit unit) throws InvalidMetricException {
-        Validator.validateMetric(key, value, unit);
-        metricDirective.putMetric(key, value, unit);
-    }
+        putMetric(key, value, unit, StorageResolution.STANDARD);
+   }
 
     /**
      * Add a metric measurement to the context without a unit Multiple calls using the same key will
@@ -134,7 +168,7 @@ public class MetricsContext {
      * @throws InvalidMetricException if the metric is invalid
      */
     public void putMetric(String key, double value) throws InvalidMetricException {
-        putMetric(key, value, Unit.NONE);
+        putMetric(key, value, Unit.NONE, StorageResolution.STANDARD);
     }
 
     /**
@@ -297,12 +331,14 @@ public class MetricsContext {
                             new MetricDefinition(
                                     metric.getName(),
                                     metric.getUnit(),
+                                    metric.getStorageResolution(),
                                     metric.getValues()
                                             .subList(0, Constants.MAX_DATAPOINTS_PER_METRIC)));
                     metricDefinitions.offer(
                             new MetricDefinition(
                                     metric.getName(),
                                     metric.getUnit(),
+                                    metric.getStorageResolution(),
                                     metric.getValues()
                                             .subList(
                                                     Constants.MAX_DATAPOINTS_PER_METRIC,

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/model/MetricsContext.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/model/MetricsContext.java
@@ -34,6 +34,7 @@ public class MetricsContext {
     @Getter private final RootNode rootNode;
 
     private MetricDirective metricDirective;
+    private final Map<String, String> metricNameAndResolutionMap = new HashMap<>();
 
     public MetricsContext() {
         this(new RootNode());
@@ -119,7 +120,7 @@ public class MetricsContext {
      */
     public void putMetric(String key, double value, Unit unit, StorageResolution storageResolution)
             throws InvalidMetricException {
-        Validator.validateMetric(key, value, unit, storageResolution);
+        Validator.validateMetric(key, value, unit, storageResolution, metricNameAndResolutionMap);
         metricDirective.putMetric(key, value, unit, storageResolution);
     }
     /**

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/model/MetricsContext.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/model/MetricsContext.java
@@ -117,13 +117,14 @@ public class MetricsContext {
      * @param storageResolution The resolution of the metric
      * @throws InvalidMetricException if the metric is invalid
      */
-    public void putMetric(String key, double value, Unit unit, StorageResolution storageResolution) throws InvalidMetricException {
+    public void putMetric(String key, double value, Unit unit, StorageResolution storageResolution)
+            throws InvalidMetricException {
         Validator.validateMetric(key, value, unit, storageResolution);
         metricDirective.putMetric(key, value, unit, storageResolution);
     }
     /**
-     * Add a metric measurement to the context with a storage resolution but without a unit. Multiple calls using the same key will be stored as
-     * an array of scalar values.
+     * Add a metric measurement to the context with a storage resolution but without a unit.
+     * Multiple calls using the same key will be stored as an array of scalar values.
      *
      * <pre>{@code
      * metricContext.putMetric("Latency", 100, StorageResolution.HIGH)
@@ -134,13 +135,14 @@ public class MetricsContext {
      * @param storageResolution The resolution of the metric
      * @throws InvalidMetricException if the metric is invalid
      */
-    public void putMetric(String key, double value, StorageResolution storageResolution) throws InvalidMetricException {
+    public void putMetric(String key, double value, StorageResolution storageResolution)
+            throws InvalidMetricException {
         putMetric(key, value, Unit.NONE, storageResolution);
     }
 
     /**
-     * Add a metric measurement to the context without a storage resolution. Multiple calls using the same key will be stored as
-     * an array of scalar values.
+     * Add a metric measurement to the context without a storage resolution. Multiple calls using
+     * the same key will be stored as an array of scalar values.
      *
      * <pre>{@code
      * metricContext.putMetric("Latency", 100, Unit.MILLISECONDS)
@@ -153,7 +155,7 @@ public class MetricsContext {
      */
     public void putMetric(String key, double value, Unit unit) throws InvalidMetricException {
         putMetric(key, value, unit, StorageResolution.STANDARD);
-   }
+    }
 
     /**
      * Add a metric measurement to the context without a unit Multiple calls using the same key will

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/model/MetricsContext.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/model/MetricsContext.java
@@ -122,6 +122,9 @@ public class MetricsContext {
             throws InvalidMetricException {
         Validator.validateMetric(key, value, unit, storageResolution, metricNameAndResolutionMap);
         metricDirective.putMetric(key, value, unit, storageResolution);
+        if (!metricNameAndResolutionMap.containsKey(key)) {
+            metricNameAndResolutionMap.put(key, storageResolution);
+        }
     }
     /**
      * Add a metric measurement to the context with a storage resolution but without a unit.

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/model/StorageResolution.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/model/StorageResolution.java
@@ -42,6 +42,8 @@ public enum StorageResolution {
      */
     public static StorageResolution fromValue(int value) {
         return Stream.of(StorageResolution.values())
-                .filter(e -> e.getValue() == value).findFirst().orElse(UNKNOWN_TO_SDK_VERSION);
+                .filter(e -> e.getValue() == value)
+                .findFirst()
+                .orElse(UNKNOWN_TO_SDK_VERSION);
     }
 }

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/model/StorageResolution.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/model/StorageResolution.java
@@ -16,8 +16,6 @@
 
 package software.amazon.cloudwatchlogs.emf.model;
 
-import java.util.stream.Stream;
-
 public enum StorageResolution {
     STANDARD(60),
     HIGH(1),
@@ -31,19 +29,5 @@ public enum StorageResolution {
 
     public int getValue() {
         return this.value;
-    }
-
-    /**
-     * Use this in place of valueOf to convert the raw integer returned by the service into the enum
-     * value.
-     *
-     * @param value real value
-     * @return Storage Resolution corresponding to the value
-     */
-    public static StorageResolution fromValue(int value) {
-        return Stream.of(StorageResolution.values())
-                .filter(e -> e.getValue() == value)
-                .findFirst()
-                .orElse(UNKNOWN_TO_SDK_VERSION);
     }
 }

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/model/StorageResolution.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/model/StorageResolution.java
@@ -1,0 +1,47 @@
+/*
+ *   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package software.amazon.cloudwatchlogs.emf.model;
+
+import java.util.stream.Stream;
+
+public enum StorageResolution {
+    STANDARD(60),
+    HIGH(1),
+    UNKNOWN_TO_SDK_VERSION(-1);
+
+    private final int value;
+
+    StorageResolution(final int newValue) {
+        value = newValue;
+    }
+
+    public int getValue() {
+        return this.value;
+    }
+
+    /**
+     * Use this in place of valueOf to convert the raw integer returned by the service into the enum
+     * value.
+     *
+     * @param value real value
+     * @return Storage Resolution corresponding to the value
+     */
+    public static StorageResolution fromValue(int value) {
+        return Stream.of(StorageResolution.values())
+                .filter(e -> e.getValue() == value).findFirst().orElse(UNKNOWN_TO_SDK_VERSION);
+    }
+}

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/serializers/StorageResolutionFilter.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/serializers/StorageResolutionFilter.java
@@ -1,0 +1,15 @@
+package software.amazon.cloudwatchlogs.emf.serializers;
+
+import software.amazon.cloudwatchlogs.emf.model.StorageResolution;
+
+public class StorageResolutionFilter {
+
+    @Override
+    public boolean equals(Object obj) {
+
+        if (obj == null ||  !(obj instanceof StorageResolution)) {
+                return false;
+        }
+        return (obj.toString().equals("STANDARD"));
+    }
+}

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/serializers/StorageResolutionFilter.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/serializers/StorageResolutionFilter.java
@@ -7,8 +7,8 @@ public class StorageResolutionFilter {
     @Override
     public boolean equals(Object obj) {
 
-        if (obj == null ||  !(obj instanceof StorageResolution)) {
-                return false;
+        if (obj == null || !(obj instanceof StorageResolution)) {
+            return false;
         }
         return (obj.toString().equals("STANDARD"));
     }

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/serializers/StorageResolutionFilter.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/serializers/StorageResolutionFilter.java
@@ -7,7 +7,7 @@ public class StorageResolutionFilter {
     @Override
     public boolean equals(Object obj) {
 
-        if (obj == null || !(obj instanceof StorageResolution)) {
+        if (!(obj instanceof StorageResolution)) {
             return false;
         }
         return (obj.toString().equals("STANDARD"));

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/serializers/StorageResolutionSerializer.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/serializers/StorageResolutionSerializer.java
@@ -19,9 +19,8 @@ package software.amazon.cloudwatchlogs.emf.serializers;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
-import software.amazon.cloudwatchlogs.emf.model.StorageResolution;
-
 import java.io.IOException;
+import software.amazon.cloudwatchlogs.emf.model.StorageResolution;
 
 public class StorageResolutionSerializer extends StdSerializer<StorageResolution> {
     StorageResolutionSerializer() {

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/serializers/StorageResolutionSerializer.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/serializers/StorageResolutionSerializer.java
@@ -1,0 +1,41 @@
+/*
+ *   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package software.amazon.cloudwatchlogs.emf.serializers;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import software.amazon.cloudwatchlogs.emf.model.StorageResolution;
+
+import java.io.IOException;
+
+public class StorageResolutionSerializer extends StdSerializer<StorageResolution> {
+    StorageResolutionSerializer() {
+        this(null);
+    }
+
+    StorageResolutionSerializer(Class<StorageResolution> t) {
+        super(t);
+    }
+
+    @Override
+    public void serialize(StorageResolution value, JsonGenerator jgen, SerializerProvider provider)
+            throws IOException {
+        int resolution = value.getValue();
+        jgen.writeNumber(resolution);
+    }
+}

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/util/Validator.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/util/Validator.java
@@ -17,7 +17,6 @@
 package software.amazon.cloudwatchlogs.emf.util;
 
 import java.time.Instant;
-import java.lang.Object;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.commons.lang3.StringUtils;
@@ -95,10 +94,11 @@ public class Validator {
      * @param storageResolution Metric resolution
      * @throws InvalidMetricException if metric is invalid
      */
-    public static void validateMetric(String name, double value, Unit unit, StorageResolution storageResolution)
+    public static void validateMetric(
+            String name, double value, Unit unit, StorageResolution storageResolution)
             throws InvalidMetricException {
 
-        Map<String,String> metricNameAndResolutionMap=new HashMap<>();
+        Map<String, String> metricNameAndResolutionMap = new HashMap<>();
 
         if (name == null || name.trim().isEmpty()) {
             throw new InvalidMetricException(
@@ -120,19 +120,20 @@ public class Validator {
         if (unit == null) {
             throw new InvalidMetricException("Metric unit cannot be null");
         }
-        //TODO_M validate storageResolution ?
+        // TODO_M validate storageResolution ?
         if (storageResolution.getValue() == -1) {
             throw new InvalidMetricException("Metric resolution cannot be null");
         }
 
-        if(metricNameAndResolutionMap.containsKey(name))
-        {
-            String resolutionOfMetric=metricNameAndResolutionMap.get(name);
-            if(!resolutionOfMetric.equals(storageResolution.toString()))
-            {
-                throw new InvalidMetricException("Resolution for metrics "+name+ " is already set. A single log event cannot have a metric with two different resolutions.");
-        }}
-        else {
+        if (metricNameAndResolutionMap.containsKey(name)) {
+            String resolutionOfMetric = metricNameAndResolutionMap.get(name);
+            if (!resolutionOfMetric.equals(storageResolution.toString())) {
+                throw new InvalidMetricException(
+                        "Resolution for metrics "
+                                + name
+                                + " is already set. A single log event cannot have a metric with two different resolutions.");
+            }
+        } else {
             metricNameAndResolutionMap.put(name, storageResolution.toString());
         }
     }

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/util/Validator.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/util/Validator.java
@@ -17,9 +17,11 @@
 package software.amazon.cloudwatchlogs.emf.util;
 
 import java.time.Instant;
+import java.lang.Object;
 import org.apache.commons.lang3.StringUtils;
 import software.amazon.cloudwatchlogs.emf.Constants;
 import software.amazon.cloudwatchlogs.emf.exception.*;
+import software.amazon.cloudwatchlogs.emf.model.StorageResolution;
 import software.amazon.cloudwatchlogs.emf.model.Unit;
 
 public class Validator {
@@ -90,7 +92,7 @@ public class Validator {
      * @param unit Metric unit
      * @throws InvalidMetricException if metric is invalid
      */
-    public static void validateMetric(String name, double value, Unit unit)
+    public static void validateMetric(String name, double value, Unit unit, StorageResolution storageResolution)
             throws InvalidMetricException {
         if (name == null || name.trim().isEmpty()) {
             throw new InvalidMetricException(
@@ -111,6 +113,10 @@ public class Validator {
 
         if (unit == null) {
             throw new InvalidMetricException("Metric unit cannot be null");
+        }
+        //TODO_M validate storageResolution ?
+        if (storageResolution.getValue() == -1) {
+            throw new InvalidMetricException("Metric resolution cannot be null");
         }
     }
 

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/util/Validator.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/util/Validator.java
@@ -100,7 +100,7 @@ public class Validator {
             double value,
             Unit unit,
             StorageResolution storageResolution,
-            Map<String, String> metricNameAndResolutionMap)
+            Map<String, StorageResolution> metricNameAndResolutionMap)
             throws InvalidMetricException {
 
         if (name == null || name.trim().isEmpty()) {
@@ -129,14 +129,14 @@ public class Validator {
         }
 
         if (metricNameAndResolutionMap.containsKey(name)) {
-            if (!metricNameAndResolutionMap.get(name).equals(storageResolution.toString())) {
+            if (!metricNameAndResolutionMap.get(name).equals(storageResolution)) {
                 throw new InvalidMetricException(
                         "Resolution for metrics "
                                 + name
                                 + " is already set. A single log event cannot have a metric with two different resolutions.");
             }
         } else {
-            metricNameAndResolutionMap.put(name, storageResolution.toString());
+            metricNameAndResolutionMap.put(name, storageResolution);
         }
     }
 

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/util/Validator.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/util/Validator.java
@@ -124,8 +124,9 @@ public class Validator {
             throw new InvalidMetricException("Metric unit cannot be null");
         }
 
-        if (storageResolution == null) {
-            throw new InvalidMetricException("Metric resolution cannot be null");
+        if (storageResolution == null
+                || storageResolution == StorageResolution.UNKNOWN_TO_SDK_VERSION) {
+            throw new InvalidMetricException("Metric resolution is invalid");
         }
 
         if (metricNameAndResolutionMap.containsKey(name)) {

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/util/Validator.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/util/Validator.java
@@ -18,6 +18,8 @@ package software.amazon.cloudwatchlogs.emf.util;
 
 import java.time.Instant;
 import java.lang.Object;
+import java.util.HashMap;
+import java.util.Map;
 import org.apache.commons.lang3.StringUtils;
 import software.amazon.cloudwatchlogs.emf.Constants;
 import software.amazon.cloudwatchlogs.emf.exception.*;
@@ -90,10 +92,14 @@ public class Validator {
      * @param name Metric name
      * @param value Metric value
      * @param unit Metric unit
+     * @param storageResolution Metric resolution
      * @throws InvalidMetricException if metric is invalid
      */
     public static void validateMetric(String name, double value, Unit unit, StorageResolution storageResolution)
             throws InvalidMetricException {
+
+        Map<String,String> metricNameAndResolutionMap=new HashMap<>();
+
         if (name == null || name.trim().isEmpty()) {
             throw new InvalidMetricException(
                     "Metric name " + name + " must include at least one non-whitespace character");
@@ -117,6 +123,17 @@ public class Validator {
         //TODO_M validate storageResolution ?
         if (storageResolution.getValue() == -1) {
             throw new InvalidMetricException("Metric resolution cannot be null");
+        }
+
+        if(metricNameAndResolutionMap.containsKey(name))
+        {
+            String resolutionOfMetric=metricNameAndResolutionMap.get(name);
+            if(!resolutionOfMetric.equals(storageResolution.toString()))
+            {
+                throw new InvalidMetricException("Resolution for metrics "+name+ " is already set. A single log event cannot have a metric with two different resolutions.");
+        }}
+        else {
+            metricNameAndResolutionMap.put(name, storageResolution.toString());
         }
     }
 

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/util/Validator.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/util/Validator.java
@@ -26,6 +26,8 @@ import software.amazon.cloudwatchlogs.emf.model.StorageResolution;
 import software.amazon.cloudwatchlogs.emf.model.Unit;
 
 public class Validator {
+    public static Map<String, String> metricNameAndResolutionMap = new HashMap<>();
+
     private Validator() {
         throw new IllegalStateException("Utility class");
     }
@@ -98,8 +100,6 @@ public class Validator {
             String name, double value, Unit unit, StorageResolution storageResolution)
             throws InvalidMetricException {
 
-        Map<String, String> metricNameAndResolutionMap = new HashMap<>();
-
         if (name == null || name.trim().isEmpty()) {
             throw new InvalidMetricException(
                     "Metric name " + name + " must include at least one non-whitespace character");
@@ -120,8 +120,8 @@ public class Validator {
         if (unit == null) {
             throw new InvalidMetricException("Metric unit cannot be null");
         }
-        // TODO_M validate storageResolution ?
-        if (storageResolution.getValue() == -1) {
+
+        if (storageResolution == null) {
             throw new InvalidMetricException("Metric resolution cannot be null");
         }
 

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/util/Validator.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/util/Validator.java
@@ -132,7 +132,7 @@ public class Validator {
         if (metricNameAndResolutionMap.containsKey(name)) {
             if (!metricNameAndResolutionMap.get(name).equals(storageResolution)) {
                 throw new InvalidMetricException(
-                        "Resolution for metrics "
+                        "Resolution for metric "
                                 + name
                                 + " is already set. A single log event cannot have a metric with two different resolutions.");
             }

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/util/Validator.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/util/Validator.java
@@ -17,7 +17,6 @@
 package software.amazon.cloudwatchlogs.emf.util;
 
 import java.time.Instant;
-import java.util.HashMap;
 import java.util.Map;
 import org.apache.commons.lang3.StringUtils;
 import software.amazon.cloudwatchlogs.emf.Constants;
@@ -26,7 +25,6 @@ import software.amazon.cloudwatchlogs.emf.model.StorageResolution;
 import software.amazon.cloudwatchlogs.emf.model.Unit;
 
 public class Validator {
-    public static Map<String, String> metricNameAndResolutionMap = new HashMap<>();
 
     private Validator() {
         throw new IllegalStateException("Utility class");
@@ -94,10 +92,15 @@ public class Validator {
      * @param value Metric value
      * @param unit Metric unit
      * @param storageResolution Metric resolution
+     * @param metricNameAndResolutionMap Map to validate Metric
      * @throws InvalidMetricException if metric is invalid
      */
     public static void validateMetric(
-            String name, double value, Unit unit, StorageResolution storageResolution)
+            String name,
+            double value,
+            Unit unit,
+            StorageResolution storageResolution,
+            Map<String, String> metricNameAndResolutionMap)
             throws InvalidMetricException {
 
         if (name == null || name.trim().isEmpty()) {
@@ -126,8 +129,7 @@ public class Validator {
         }
 
         if (metricNameAndResolutionMap.containsKey(name)) {
-            String resolutionOfMetric = metricNameAndResolutionMap.get(name);
-            if (!resolutionOfMetric.equals(storageResolution.toString())) {
+            if (!metricNameAndResolutionMap.get(name).equals(storageResolution.toString())) {
                 throw new InvalidMetricException(
                         "Resolution for metrics "
                                 + name

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/util/Validator.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/util/Validator.java
@@ -129,15 +129,12 @@ public class Validator {
             throw new InvalidMetricException("Metric resolution is invalid");
         }
 
-        if (metricNameAndResolutionMap.containsKey(name)) {
-            if (!metricNameAndResolutionMap.get(name).equals(storageResolution)) {
-                throw new InvalidMetricException(
-                        "Resolution for metric "
-                                + name
-                                + " is already set. A single log event cannot have a metric with two different resolutions.");
-            }
-        } else {
-            metricNameAndResolutionMap.put(name, storageResolution);
+        if ((metricNameAndResolutionMap.containsKey(name))
+                && (!metricNameAndResolutionMap.get(name).equals(storageResolution))) {
+            throw new InvalidMetricException(
+                    "Resolution for metric "
+                            + name
+                            + " is already set. A single log event cannot have a metric with two different resolutions.");
         }
     }
 

--- a/src/test/java/software/amazon/cloudwatchlogs/emf/logger/MetricsLoggerTest.java
+++ b/src/test/java/software/amazon/cloudwatchlogs/emf/logger/MetricsLoggerTest.java
@@ -362,6 +362,16 @@ class MetricsLoggerTest {
     }
 
     @Test
+    void whenPutMetric_withSameMetricDifferentStorageResolutionAfterFlush_thenAllow()
+            throws InvalidMetricException {
+        logger.putMetric("Count", 1);
+        logger.flush();
+        logger.putMetric("Count", 1.0, StorageResolution.HIGH);
+        logger.flush();
+        assertTrue(sink.getLogEvents().get(0).contains("StorageResolution"));
+    }
+
+    @Test
     void whenPutMetric_withDifferentStorageResolution_thenThrowInvalidMetricException() {
         assertThrows(
                 InvalidMetricException.class,

--- a/src/test/java/software/amazon/cloudwatchlogs/emf/logger/MetricsLoggerTest.java
+++ b/src/test/java/software/amazon/cloudwatchlogs/emf/logger/MetricsLoggerTest.java
@@ -372,7 +372,8 @@ class MetricsLoggerTest {
     }
 
     @Test
-    void whenPutMetric_withDifferentStorageResolution_thenThrowInvalidMetricException() throws InvalidMetricException {
+    void whenPutMetric_withDifferentStorageResolution_thenThrowInvalidMetricException()
+            throws InvalidMetricException {
         logger.putMetric("test", 1);
         assertThrows(
                 InvalidMetricException.class,

--- a/src/test/java/software/amazon/cloudwatchlogs/emf/logger/MetricsLoggerTest.java
+++ b/src/test/java/software/amazon/cloudwatchlogs/emf/logger/MetricsLoggerTest.java
@@ -372,13 +372,11 @@ class MetricsLoggerTest {
     }
 
     @Test
-    void whenPutMetric_withDifferentStorageResolution_thenThrowInvalidMetricException() {
+    void whenPutMetric_withDifferentStorageResolution_thenThrowInvalidMetricException() throws InvalidMetricException {
+        logger.putMetric("test", 1);
         assertThrows(
                 InvalidMetricException.class,
-                () -> {
-                    logger.putMetric("test", 1);
-                    logger.putMetric("test", 1, StorageResolution.HIGH);
-                });
+                () -> logger.putMetric("test", 1, StorageResolution.HIGH));
     }
 
     @Test

--- a/src/test/java/software/amazon/cloudwatchlogs/emf/logger/MetricsLoggerTest.java
+++ b/src/test/java/software/amazon/cloudwatchlogs/emf/logger/MetricsLoggerTest.java
@@ -38,6 +38,8 @@ import software.amazon.cloudwatchlogs.emf.exception.InvalidNamespaceException;
 import software.amazon.cloudwatchlogs.emf.exception.InvalidTimestampException;
 import software.amazon.cloudwatchlogs.emf.model.DimensionSet;
 import software.amazon.cloudwatchlogs.emf.model.MetricsContext;
+import software.amazon.cloudwatchlogs.emf.model.StorageResolution;
+import software.amazon.cloudwatchlogs.emf.model.Unit;
 import software.amazon.cloudwatchlogs.emf.sinks.SinkShunt;
 
 class MetricsLoggerTest {
@@ -349,7 +351,24 @@ class MetricsLoggerTest {
 
     @Test
     void whenPutMetric_withNullUnit_thenThrowInvalidMetricException() {
-        assertThrows(InvalidMetricException.class, () -> logger.putMetric("test", 1, null));
+        assertThrows(InvalidMetricException.class, () -> logger.putMetric("test", 1, (Unit) null));
+    }
+
+    @Test
+    void whenPutMetric_withNullStorageResolution_thenThrowInvalidMetricException() {
+        assertThrows(
+                InvalidMetricException.class,
+                () -> logger.putMetric("test", 1, (StorageResolution) null));
+    }
+
+    @Test
+    void whenPutMetric_withDifferentStorageResolution_thenThrowInvalidMetricException() {
+        assertThrows(
+                InvalidMetricException.class,
+                () -> {
+                    logger.putMetric("test", 1);
+                    logger.putMetric("test", 1, StorageResolution.HIGH);
+                });
     }
 
     @Test

--- a/src/test/java/software/amazon/cloudwatchlogs/emf/model/MetricDefinitionTest.java
+++ b/src/test/java/software/amazon/cloudwatchlogs/emf/model/MetricDefinitionTest.java
@@ -56,7 +56,8 @@ public class MetricDefinitionTest {
     public void testSerializeMetricDefinitionWithoutUnitWithStandardStorageResolution()
             throws JsonProcessingException {
         ObjectMapper objectMapper = new ObjectMapper();
-        MetricDefinition metricDefinition = new MetricDefinition("Time", StorageResolution.STANDARD, 10);
+        MetricDefinition metricDefinition =
+                new MetricDefinition("Time", StorageResolution.STANDARD, 10);
         String metricString = objectMapper.writeValueAsString(metricDefinition);
 
         assertEquals("{\"Name\":\"Time\",\"Unit\":\"None\"}", metricString);

--- a/src/test/java/software/amazon/cloudwatchlogs/emf/model/MetricDefinitionTest.java
+++ b/src/test/java/software/amazon/cloudwatchlogs/emf/model/MetricDefinitionTest.java
@@ -32,6 +32,27 @@ public class MetricDefinitionTest {
     }
 
     @Test
+    public void testSerializeMetricDefinitionWithoutUnitWithStorageResolution()
+            throws JsonProcessingException {
+        ObjectMapper objectMapper = new ObjectMapper();
+        MetricDefinition metricDefinition =
+                new MetricDefinition("Time", StorageResolution.HIGH, 10);
+        String metricString = objectMapper.writeValueAsString(metricDefinition);
+
+        assertEquals("{\"Name\":\"Time\",\"Unit\":\"None\",\"StorageResolution\":1}", metricString);
+    }
+
+    @Test
+    public void testSerializeMetricDefinitionWithUnitWithoutStorageResolution()
+            throws JsonProcessingException {
+        ObjectMapper objectMapper = new ObjectMapper();
+        MetricDefinition metricDefinition = new MetricDefinition("Time", Unit.MILLISECONDS, 10);
+        String metricString = objectMapper.writeValueAsString(metricDefinition);
+
+        assertEquals("{\"Name\":\"Time\",\"Unit\":\"Milliseconds\"}", metricString);
+    }
+
+    @Test
     public void testSerializeMetricDefinitionWithoutUnit() throws JsonProcessingException {
         ObjectMapper objectMapper = new ObjectMapper();
         MetricDefinition metricDefinition = new MetricDefinition("Time");
@@ -43,10 +64,13 @@ public class MetricDefinitionTest {
     @Test
     public void testSerializeMetricDefinition() throws JsonProcessingException {
         ObjectMapper objectMapper = new ObjectMapper();
-        MetricDefinition metricDefinition = new MetricDefinition("Time", Unit.MILLISECONDS, 10);
+        MetricDefinition metricDefinition =
+                new MetricDefinition("Time", Unit.MILLISECONDS, StorageResolution.HIGH, 10);
         String metricString = objectMapper.writeValueAsString(metricDefinition);
 
-        assertEquals("{\"Name\":\"Time\",\"Unit\":\"Milliseconds\"}", metricString);
+        assertEquals(
+                "{\"Name\":\"Time\",\"Unit\":\"Milliseconds\",\"StorageResolution\":1}",
+                metricString);
     }
 
     @Test

--- a/src/test/java/software/amazon/cloudwatchlogs/emf/model/MetricDefinitionTest.java
+++ b/src/test/java/software/amazon/cloudwatchlogs/emf/model/MetricDefinitionTest.java
@@ -32,7 +32,7 @@ public class MetricDefinitionTest {
     }
 
     @Test
-    public void testSerializeMetricDefinitionWithoutUnitWithStorageResolution()
+    public void testSerializeMetricDefinitionWithoutUnitWithHighStorageResolution()
             throws JsonProcessingException {
         ObjectMapper objectMapper = new ObjectMapper();
         MetricDefinition metricDefinition =
@@ -50,6 +50,16 @@ public class MetricDefinitionTest {
         String metricString = objectMapper.writeValueAsString(metricDefinition);
 
         assertEquals("{\"Name\":\"Time\",\"Unit\":\"Milliseconds\"}", metricString);
+    }
+
+    @Test
+    public void testSerializeMetricDefinitionWithoutUnitWithStandardStorageResolution()
+            throws JsonProcessingException {
+        ObjectMapper objectMapper = new ObjectMapper();
+        MetricDefinition metricDefinition = new MetricDefinition("Time", StorageResolution.STANDARD, 10);
+        String metricString = objectMapper.writeValueAsString(metricDefinition);
+
+        assertEquals("{\"Name\":\"Time\",\"Unit\":\"None\"}", metricString);
     }
 
     @Test

--- a/src/test/java/software/amazon/cloudwatchlogs/emf/model/MetricDirectiveTest.java
+++ b/src/test/java/software/amazon/cloudwatchlogs/emf/model/MetricDirectiveTest.java
@@ -91,6 +91,51 @@ class MetricDirectiveTest {
     }
 
     @Test
+    void testPutMetricWithoutStorageResolution() throws JsonProcessingException {
+        MetricDirective metricDirective = new MetricDirective();
+        metricDirective.putMetric("Time", 10);
+
+        String serializedMetricDirective = objectMapper.writeValueAsString(metricDirective);
+
+        Assertions.assertEquals(
+                StorageResolution.STANDARD,
+                metricDirective.getMetrics().get("Time").getStorageResolution());
+        Assertions.assertEquals(
+                "{\"Dimensions\":[[]],\"Metrics\":[{\"Name\":\"Time\",\"Unit\":\"None\"}],\"Namespace\":\"aws-embedded-metrics\"}",
+                serializedMetricDirective);
+    }
+
+    @Test
+    void testPutMetricWithStandardStorageResolution() throws JsonProcessingException {
+        MetricDirective metricDirective = new MetricDirective();
+        metricDirective.putMetric("Time", 10, StorageResolution.STANDARD);
+
+        String serializedMetricDirective = objectMapper.writeValueAsString(metricDirective);
+
+        Assertions.assertEquals(
+                StorageResolution.STANDARD,
+                metricDirective.getMetrics().get("Time").getStorageResolution());
+        Assertions.assertEquals(
+                "{\"Dimensions\":[[]],\"Metrics\":[{\"Name\":\"Time\",\"Unit\":\"None\"}],\"Namespace\":\"aws-embedded-metrics\"}",
+                serializedMetricDirective);
+    }
+
+    @Test
+    void testPutMetricWithHighStorageResolution() throws JsonProcessingException {
+        MetricDirective metricDirective = new MetricDirective();
+        metricDirective.putMetric("Time", 10, StorageResolution.HIGH);
+
+        String serializedMetricDirective = objectMapper.writeValueAsString(metricDirective);
+
+        Assertions.assertEquals(
+                StorageResolution.HIGH,
+                metricDirective.getMetrics().get("Time").getStorageResolution());
+        Assertions.assertEquals(
+                "{\"Dimensions\":[[]],\"Metrics\":[{\"Name\":\"Time\",\"StorageResolution\":1,\"Unit\":\"None\"}],\"Namespace\":\"aws-embedded-metrics\"}",
+                serializedMetricDirective);
+    }
+
+    @Test
     void testPutDimensions()
             throws JsonProcessingException, InvalidDimensionException,
                     DimensionSetExceededException {

--- a/src/test/java/software/amazon/cloudwatchlogs/emf/model/MetricsContextTest.java
+++ b/src/test/java/software/amazon/cloudwatchlogs/emf/model/MetricsContextTest.java
@@ -200,11 +200,14 @@ class MetricsContextTest {
             String name = metric.get("Name");
             Unit unit = Unit.fromValue(metric.get("Unit"));
             Object value = rootNode.get(name);
-            StorageResolution storageResolution = StorageResolution.fromValue(Integer.parseInt(metric.get("StorageResolution")));
+            StorageResolution storageResolution =
+                    StorageResolution.fromValue(Integer.parseInt(metric.get("StorageResolution")));
             if (value instanceof ArrayList) {
-                metricDefinitions.add(new MetricDefinition(name, unit, storageResolution, (ArrayList) value));
+                metricDefinitions.add(
+                        new MetricDefinition(name, unit, storageResolution, (ArrayList) value));
             } else {
-                metricDefinitions.add(new MetricDefinition(name, unit, storageResolution, (double) value));
+                metricDefinitions.add(
+                        new MetricDefinition(name, unit, storageResolution, (double) value));
             }
         }
         return metricDefinitions;

--- a/src/test/java/software/amazon/cloudwatchlogs/emf/model/MetricsContextTest.java
+++ b/src/test/java/software/amazon/cloudwatchlogs/emf/model/MetricsContextTest.java
@@ -200,10 +200,11 @@ class MetricsContextTest {
             String name = metric.get("Name");
             Unit unit = Unit.fromValue(metric.get("Unit"));
             Object value = rootNode.get(name);
+            StorageResolution storageResolution = StorageResolution.fromValue(Integer.parseInt(metric.get("StorageResolution")));
             if (value instanceof ArrayList) {
-                metricDefinitions.add(new MetricDefinition(name, unit, (ArrayList) value));
+                metricDefinitions.add(new MetricDefinition(name, unit, storageResolution, (ArrayList) value));
             } else {
-                metricDefinitions.add(new MetricDefinition(name, unit, (double) value));
+                metricDefinitions.add(new MetricDefinition(name, unit, storageResolution, (double) value));
             }
         }
         return metricDefinitions;

--- a/src/test/java/software/amazon/cloudwatchlogs/emf/model/MetricsContextTest.java
+++ b/src/test/java/software/amazon/cloudwatchlogs/emf/model/MetricsContextTest.java
@@ -200,14 +200,12 @@ class MetricsContextTest {
             String name = metric.get("Name");
             Unit unit = Unit.fromValue(metric.get("Unit"));
             Object value = rootNode.get(name);
-            StorageResolution storageResolution =
-                    StorageResolution.fromValue(Integer.parseInt(metric.get("StorageResolution")));
             if (value instanceof ArrayList) {
                 metricDefinitions.add(
-                        new MetricDefinition(name, unit, storageResolution, (ArrayList) value));
+                        new MetricDefinition(
+                                name, unit, StorageResolution.STANDARD, (ArrayList) value));
             } else {
-                metricDefinitions.add(
-                        new MetricDefinition(name, unit, storageResolution, (double) value));
+                metricDefinitions.add(new MetricDefinition(name, unit, (double) value));
             }
         }
         return metricDefinitions;


### PR DESCRIPTION
*Description of changes:*

- Added support for High Resolution Metrics. Customers can specify an optional property - storageResolution of the metrics in putMetric() call. If resolution is not specified, metrics will be emitted with standard resolution. 
- Added UTs and modified integration tests for the changes.
- Updated README.md and _examples_ folder.
- Updated the canary. See the image below for memory usage. (Note: We will have to wait until the feature is enabled to get metrics in high resolution for the canary)
<img width="1350" alt="Screen Shot 2022-12-21 at 3 47 58 PM" src="https://user-images.githubusercontent.com/35884424/209024770-9f986c19-e0d6-41fe-a9bb-e3880952860c.png">

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
