### PR TITLE
Change validation exceptions to unchecked exceptions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ allprojects {
 		targetCompatibility = JavaVersion.VERSION_1_8
 	}
 
-	version = '4.1.1'
+	version = '4.1.2'
 }
 
 java {

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/exception/DimensionSetExceededException.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/exception/DimensionSetExceededException.java
@@ -18,7 +18,7 @@ package software.amazon.cloudwatchlogs.emf.exception;
 
 import software.amazon.cloudwatchlogs.emf.Constants;
 
-public class DimensionSetExceededException extends Exception {
+public class DimensionSetExceededException extends RuntimeException {
 
     public DimensionSetExceededException() {
         super(

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/exception/InvalidDimensionException.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/exception/InvalidDimensionException.java
@@ -16,7 +16,7 @@
 
 package software.amazon.cloudwatchlogs.emf.exception;
 
-public class InvalidDimensionException extends Exception {
+public class InvalidDimensionException extends IllegalArgumentException {
     public InvalidDimensionException(String message) {
         super(message);
     }

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/exception/InvalidMetricException.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/exception/InvalidMetricException.java
@@ -16,7 +16,7 @@
 
 package software.amazon.cloudwatchlogs.emf.exception;
 
-public class InvalidMetricException extends Exception {
+public class InvalidMetricException extends IllegalArgumentException {
     public InvalidMetricException(String message) {
         super(message);
     }

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/exception/InvalidNamespaceException.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/exception/InvalidNamespaceException.java
@@ -16,7 +16,7 @@
 
 package software.amazon.cloudwatchlogs.emf.exception;
 
-public class InvalidNamespaceException extends Exception {
+public class InvalidNamespaceException extends IllegalArgumentException {
     public InvalidNamespaceException(String message) {
         super(message);
     }

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/exception/InvalidTimestampException.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/exception/InvalidTimestampException.java
@@ -16,7 +16,7 @@
 
 package software.amazon.cloudwatchlogs.emf.exception;
 
-public class InvalidTimestampException extends Exception {
+public class InvalidTimestampException extends IllegalArgumentException {
     public InvalidTimestampException(String message) {
         super(message);
     }

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/model/DimensionSet.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/model/DimensionSet.java
@@ -40,10 +40,8 @@ public class DimensionSet {
      * @param v1 Value of the single dimension
      * @return a DimensionSet from the parameters
      * @throws InvalidDimensionException if the dimension name or value is invalid
-     * @throws DimensionSetExceededException if the number of dimensions exceeds the limit
      */
-    public static DimensionSet of(String d1, String v1)
-            throws InvalidDimensionException, DimensionSetExceededException {
+    public static DimensionSet of(String d1, String v1) throws InvalidDimensionException {
         return fromEntries(entryOf(d1, v1));
     }
 
@@ -56,10 +54,9 @@ public class DimensionSet {
      * @param v2 Value of the second dimension
      * @return a DimensionSet from the parameters
      * @throws InvalidDimensionException if the dimension name or value is invalid
-     * @throws DimensionSetExceededException if the number of dimensions exceeds the limit
      */
     public static DimensionSet of(String d1, String v1, String d2, String v2)
-            throws InvalidDimensionException, DimensionSetExceededException {
+            throws InvalidDimensionException {
         return fromEntries(entryOf(d1, v1), entryOf(d2, v2));
     }
 
@@ -74,10 +71,9 @@ public class DimensionSet {
      * @param v3 Value of the third dimension
      * @return a DimensionSet from the parameters
      * @throws InvalidDimensionException if the dimension name or value is invalid
-     * @throws DimensionSetExceededException if the number of dimensions exceeds the limit
      */
     public static DimensionSet of(String d1, String v1, String d2, String v2, String d3, String v3)
-            throws InvalidDimensionException, DimensionSetExceededException {
+            throws InvalidDimensionException {
         return fromEntries(entryOf(d1, v1), entryOf(d2, v2), entryOf(d3, v3));
     }
 
@@ -94,11 +90,10 @@ public class DimensionSet {
      * @param v4 Value of the fourth dimension
      * @return a DimensionSet from the parameters
      * @throws InvalidDimensionException if the dimension name or value is invalid
-     * @throws DimensionSetExceededException if the number of dimensions exceeds the limit
      */
     public static DimensionSet of(
             String d1, String v1, String d2, String v2, String d3, String v3, String d4, String v4)
-            throws InvalidDimensionException, DimensionSetExceededException {
+            throws InvalidDimensionException {
 
         return fromEntries(entryOf(d1, v1), entryOf(d2, v2), entryOf(d3, v3), entryOf(d4, v4));
     }
@@ -118,7 +113,6 @@ public class DimensionSet {
      * @param v5 Value of the fifth dimension
      * @return a DimensionSet from the parameters
      * @throws InvalidDimensionException if the dimension name or value is invalid
-     * @throws DimensionSetExceededException if the number of dimensions exceeds the limit
      */
     public static DimensionSet of(
             String d1,
@@ -131,7 +125,7 @@ public class DimensionSet {
             String v4,
             String d5,
             String v5)
-            throws InvalidDimensionException, DimensionSetExceededException {
+            throws InvalidDimensionException {
 
         return fromEntries(
                 entryOf(d1, v1),


### PR DESCRIPTION
*Description of changes:*

With the release of version 4, we introduced validation features aimed at providing immediate feedback on invalid properties and metrics. This proactive approach was designed to save customers time by eliminating the need to troubleshoot missing metrics in CloudWatch. Initially, we implemented these validations as checked exceptions to ensure they were explicitly handled.

However, after careful consideration of recent customer feedback, we recognize that this design choice may not align with all use cases. To offer a more flexible integration, we are transitioning our validation exceptions from checked to unchecked. This change is intended to streamline error handling and improve the overall developer experience.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
