### PR TITLE
added a test storing the same metric with different dimenstion sets

### DIFF
--- a/src/test/java/software/amazon/cloudwatchlogs/emf/logger/MetricsLoggerTest.java
+++ b/src/test/java/software/amazon/cloudwatchlogs/emf/logger/MetricsLoggerTest.java
@@ -531,6 +531,28 @@ class MetricsLoggerTest {
         assertFalse(sink.getLogEvents().get(0).contains("Count"));
     }
 
+    @Test
+    void putMetricWithSameNameAndDifferentDimensionSet_shouldNotAggregateCounts() {
+        MetricsLogger logger = new MetricsLogger(envProvider);
+        logger.setDimensions(DimensionSet.of("foo", "bar"));
+        logger.putMetric("metric", 1);
+        logger.setDimensions(DimensionSet.of("barf", "baz"));
+        logger.putMetric("metric", 1);
+        logger.flush();
+
+        List<String> events = sink.getLogEvents();
+
+        assertEquals(2, events.size());
+
+        assertTrue(events.get(0).contains("metric"));
+        assertTrue(events.get(0).contains("foo"));
+        assertTrue(events.get(0).contains("bar"));
+
+        assertTrue(events.get(1).contains("metric"));
+        assertTrue(events.get(1).contains("barf"));
+        assertTrue(events.get(1).contains("baz"));
+    }
+
     private void expectDimension(String dimension, String value)
             throws DimensionSetExceededException {
         List<DimensionSet> dimensions = sink.getContext().getDimensions();


### PR DESCRIPTION
According to the documentation (https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/cloudwatch_concepts.html#Dimension) each metric stored with a different set of dimensions should result in a separate event

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
