### PR TITLE
Allow STDOUT overrides for AgentBasedEnvironments

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,6 +373,24 @@ config.setAgentEndpoint("udp://127.0.0.1:1000");
 AWS_EMF_AGENT_ENDPOINT="udp://127.0.0.1:1000"
 ```
 
+**WriteToStdout**: For agent-based platforms, setting this configuration to `true` will make the `MetricsLogger` write to `stdout` rather than sending them to the agent. The default value for this configuration is `false`. This configuration has no effect for non-agent-based platforms.
+
+If an `EnvironmentOverride` is provided, this configuration will apply to the overriden environment if the environment is an agent-based platform
+
+Example:
+
+```java
+// in process
+import software.amazon.cloudwatchlogs.emf.config.Configuration;
+import software.amazon.cloudwatchlogs.emf.config.EnvironmentConfigurationProvider;
+
+Configuration config = EnvironmentConfigurationProvider.getConfig();
+config.setShouldWriteToStdout(true);
+
+// environment
+AWS_EMF_WRITE_TO_STDOUT="true"
+```
+
 ## Thread-safety
 
 ### Internal Synchronization

--- a/examples/README.md
+++ b/examples/README.md
@@ -38,6 +38,7 @@ With Docker images, using the `awslogs` log driver will send your container logs
 ## ECS and Fargate
 
 With ECS and Fargate, you can use the `awslogs` log driver to have your logs sent to CloudWatch Logs on your behalf. After configuring your task to use the `awslogs` log driver, you may write your EMF logs to STDOUT and they will be processed.
+To write your EMF logs to STDOUT, set the environment variable `WRITE_TO_STDOUT=true`
 
 [ECS documentation on `awslogs` log driver](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/using_awslogs.html)
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -38,7 +38,7 @@ With Docker images, using the `awslogs` log driver will send your container logs
 ## ECS and Fargate
 
 With ECS and Fargate, you can use the `awslogs` log driver to have your logs sent to CloudWatch Logs on your behalf. After configuring your task to use the `awslogs` log driver, you may write your EMF logs to STDOUT and they will be processed.
-To write your EMF logs to STDOUT, set the environment variable `WRITE_TO_STDOUT=true`
+To write your EMF logs to STDOUT, set the environment variable `AWS_EMF_WRITE_TO_STDOUT=true`
 
 [ECS documentation on `awslogs` log driver](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/using_awslogs.html)
 

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/config/Configuration.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/config/Configuration.java
@@ -59,6 +59,8 @@ public class Configuration {
     /** Queue length for asynchronous sinks. */
     @Setter @Getter int asyncBufferSize = Constants.DEFAULT_ASYNC_BUFFER_SIZE;
 
+    @Setter private boolean shouldWriteToStdout;
+
     public Optional<String> getServiceName() {
         return getStringOptional(serviceName);
     }
@@ -91,5 +93,9 @@ public class Configuration {
             return Optional.empty();
         }
         return Optional.of(value);
+    }
+
+    public boolean shouldWriteToStdout() {
+        return shouldWriteToStdout;
     }
 }

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/config/ConfigurationKeys.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/config/ConfigurationKeys.java
@@ -28,4 +28,5 @@ public class ConfigurationKeys {
     public static final String AGENT_ENDPOINT = "AGENT_ENDPOINT";
     public static final String ENVIRONMENT_OVERRIDE = "ENVIRONMENT";
     public static final String ASYNC_BUFFER_SIZE = "ASYNC_BUFFER_SIZE";
+    public static final String WRITE_TO_STDOUT = "WRITE_TO_STDOUT";
 }

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/config/EnvironmentConfigurationProvider.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/config/EnvironmentConfigurationProvider.java
@@ -42,7 +42,8 @@ public class EnvironmentConfigurationProvider {
                 getEnvVar(ConfigurationKeys.AGENT_ENDPOINT),
                 getEnvironmentOverride(),
                 getIntOrDefault(
-                        ConfigurationKeys.ASYNC_BUFFER_SIZE, Constants.DEFAULT_ASYNC_BUFFER_SIZE));
+                        ConfigurationKeys.ASYNC_BUFFER_SIZE, Constants.DEFAULT_ASYNC_BUFFER_SIZE),
+                Boolean.parseBoolean(getEnvVar(ConfigurationKeys.WRITE_TO_STDOUT)));
     }
 
     private static Environments getEnvironmentOverride() {

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/environment/AgentBasedEnvironment.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/environment/AgentBasedEnvironment.java
@@ -20,7 +20,6 @@ import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import software.amazon.cloudwatchlogs.emf.Constants;
 import software.amazon.cloudwatchlogs.emf.config.Configuration;
-import software.amazon.cloudwatchlogs.emf.config.SystemWrapper;
 import software.amazon.cloudwatchlogs.emf.sinks.AgentSink;
 import software.amazon.cloudwatchlogs.emf.sinks.ConsoleSink;
 import software.amazon.cloudwatchlogs.emf.sinks.Endpoint;
@@ -77,22 +76,22 @@ public abstract class AgentBasedEnvironment implements Environment {
                     endpoint = Endpoint.fromURL(config.getAgentEndpoint().get());
                 } else {
                     log.info(
-                        "Endpoint is not defined. Using default: {}",
-                        Endpoint.DEFAULT_TCP_ENDPOINT);
+                            "Endpoint is not defined. Using default: {}",
+                            Endpoint.DEFAULT_TCP_ENDPOINT);
                     endpoint = Endpoint.DEFAULT_TCP_ENDPOINT;
                 }
                 sink =
-                    new AgentSink(
-                        getLogGroupName(),
-                        getLogStreamName(),
-                        endpoint,
-                        new SocketClientFactory(),
-                        config.getAsyncBufferSize(),
-                        () ->
-                            new FibonacciRetryStrategy(
-                                Constants.MIN_BACKOFF_MILLIS,
-                                Constants.MAX_BACKOFF_MILLIS,
-                                Constants.MAX_BACKOFF_JITTER));
+                        new AgentSink(
+                                getLogGroupName(),
+                                getLogStreamName(),
+                                endpoint,
+                                new SocketClientFactory(),
+                                config.getAsyncBufferSize(),
+                                () ->
+                                        new FibonacciRetryStrategy(
+                                                Constants.MIN_BACKOFF_MILLIS,
+                                                Constants.MAX_BACKOFF_MILLIS,
+                                                Constants.MAX_BACKOFF_JITTER));
             }
         }
         return sink;

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/environment/AgentBasedEnvironment.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/environment/AgentBasedEnvironment.java
@@ -30,16 +30,11 @@ import software.amazon.cloudwatchlogs.emf.sinks.retry.FibonacciRetryStrategy;
 
 @Slf4j
 public abstract class AgentBasedEnvironment implements Environment {
-    private static final String WRITE_TO_STDOUT = "WRITE_TO_STDOUT";
-    private final boolean shouldWriteToStdout;
     private final Configuration config;
     private ISink sink;
 
     protected AgentBasedEnvironment(Configuration config) {
         this.config = config;
-        shouldWriteToStdout = Optional.ofNullable(SystemWrapper.getenv(WRITE_TO_STDOUT))
-            .map(Boolean::parseBoolean)
-            .orElse(false);
     }
 
     @Override
@@ -74,7 +69,7 @@ public abstract class AgentBasedEnvironment implements Environment {
     @Override
     public ISink getSink() {
         if (sink == null) {
-            if (shouldWriteToStdout) {
+            if (config.shouldWriteToStdout()) {
                 sink = new ConsoleSink();
             } else {
                 Endpoint endpoint;

--- a/src/test/java/software/amazon/cloudwatchlogs/emf/config/EnvironmentConfigurationProviderTest.java
+++ b/src/test/java/software/amazon/cloudwatchlogs/emf/config/EnvironmentConfigurationProviderTest.java
@@ -40,6 +40,7 @@ public class EnvironmentConfigurationProviderTest {
         putEnv("AWS_EMF_AGENT_ENDPOINT", "Endpoint");
         putEnv("AWS_EMF_ENVIRONMENT", "Agent");
         putEnv("AWS_EMF_ASYNC_BUFFER_SIZE", "9999");
+        putEnv("AWS_EMF_WRITE_TO_STDOUT", "true");
 
         Configuration config = EnvironmentConfigurationProvider.createConfig();
 
@@ -50,6 +51,7 @@ public class EnvironmentConfigurationProviderTest {
         assertEquals("Endpoint", config.getAgentEndpoint().get());
         assertEquals(Environments.Agent, config.getEnvironmentOverride());
         assertEquals(9999, config.getAsyncBufferSize());
+        assertTrue(config.shouldWriteToStdout());
     }
 
     @Test
@@ -59,10 +61,20 @@ public class EnvironmentConfigurationProviderTest {
 
         // act
         putEnv("AWS_EMF_ASYNC_BUFFER_SIZE", "NaN");
+        putEnv("AWS_EMF_WRITE_TO_STDOUT", "notABool");
 
         // assert
         Configuration config = EnvironmentConfigurationProvider.createConfig();
         assertEquals(100, config.getAsyncBufferSize());
+        assertFalse(config.shouldWriteToStdout());
+    }
+
+    @Test
+    public void emptyEnvironmentValuesFallbackToExpectedDefaults() {
+        // assert
+        Configuration config = EnvironmentConfigurationProvider.createConfig();
+        assertEquals(100, config.getAsyncBufferSize());
+        assertFalse(config.shouldWriteToStdout());
     }
 
     private void putEnv(String key, String value) {

--- a/src/test/java/software/amazon/cloudwatchlogs/emf/environment/AgentBasedEnvironmentTest.java
+++ b/src/test/java/software/amazon/cloudwatchlogs/emf/environment/AgentBasedEnvironmentTest.java
@@ -1,5 +1,8 @@
 package software.amazon.cloudwatchlogs.emf.environment;
 
+import static org.junit.Assert.assertEquals;
+import static org.powermock.api.mockito.PowerMockito.mock;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -14,20 +17,26 @@ import software.amazon.cloudwatchlogs.emf.sinks.ConsoleSink;
 import software.amazon.cloudwatchlogs.emf.sinks.Endpoint;
 import software.amazon.cloudwatchlogs.emf.sinks.ISink;
 
-import static org.junit.Assert.assertEquals;
-import static org.powermock.api.mockito.PowerMockito.mock;
-
 @RunWith(PowerMockRunner.class)
-@PrepareForTest( {SystemWrapper.class, AgentBasedEnvironment.class} )
+@PrepareForTest({SystemWrapper.class, AgentBasedEnvironment.class})
 public class AgentBasedEnvironmentTest {
     public static class AgentBasedEnvironmentTestImplementation extends AgentBasedEnvironment {
-        protected AgentBasedEnvironmentTestImplementation(Configuration config) { super(config); }
+        protected AgentBasedEnvironmentTestImplementation(Configuration config) {
+            super(config);
+        }
+
         @Override
-        public boolean probe() { return false; }
+        public boolean probe() {
+            return false;
+        }
+
         @Override
-        public String getType() { return null; }
+        public String getType() {
+            return null;
+        }
+
         @Override
-        public void configureContext(MetricsContext context) { }
+        public void configureContext(MetricsContext context) {}
     }
 
     private Configuration configuration;
@@ -40,11 +49,14 @@ public class AgentBasedEnvironmentTest {
     @Test
     public void testGetSinkWithDefaultEndpoint() throws Exception {
         AgentSink mockedSink = mock(AgentSink.class);
-        PowerMockito.whenNew(AgentSink.class).withAnyArguments().then(invocation -> {
-            Endpoint endpoint = invocation.getArgument(2);
-            assertEquals(Endpoint.DEFAULT_TCP_ENDPOINT, endpoint);
-            return mockedSink;
-        });
+        PowerMockito.whenNew(AgentSink.class)
+                .withAnyArguments()
+                .then(
+                        invocation -> {
+                            Endpoint endpoint = invocation.getArgument(2);
+                            assertEquals(Endpoint.DEFAULT_TCP_ENDPOINT, endpoint);
+                            return mockedSink;
+                        });
 
         AgentBasedEnvironment env = new AgentBasedEnvironmentTestImplementation(configuration);
         ISink sink = env.getSink();
@@ -57,11 +69,14 @@ public class AgentBasedEnvironmentTest {
         String endpointUrl = "http://configured-endpoint:1234";
         configuration.setAgentEndpoint(endpointUrl);
         AgentSink mockedSink = mock(AgentSink.class);
-        PowerMockito.whenNew(AgentSink.class).withAnyArguments().then(invocation -> {
-            Endpoint endpoint = invocation.getArgument(2);
-            assertEquals(Endpoint.fromURL(endpointUrl), endpoint);
-            return mockedSink;
-        });
+        PowerMockito.whenNew(AgentSink.class)
+                .withAnyArguments()
+                .then(
+                        invocation -> {
+                            Endpoint endpoint = invocation.getArgument(2);
+                            assertEquals(Endpoint.fromURL(endpointUrl), endpoint);
+                            return mockedSink;
+                        });
 
         AgentBasedEnvironment env = new AgentBasedEnvironmentTestImplementation(configuration);
         ISink sink = env.getSink();

--- a/src/test/java/software/amazon/cloudwatchlogs/emf/environment/AgentBasedEnvironmentTest.java
+++ b/src/test/java/software/amazon/cloudwatchlogs/emf/environment/AgentBasedEnvironmentTest.java
@@ -71,8 +71,7 @@ public class AgentBasedEnvironmentTest {
 
     @Test
     public void testGetSinkOverrideToStdOut() {
-        PowerMockito.mockStatic(SystemWrapper.class);
-        PowerMockito.when(SystemWrapper.getenv("WRITE_TO_STDOUT")).thenReturn("true");
+        configuration.setShouldWriteToStdout(true);
 
         AgentBasedEnvironment env = new AgentBasedEnvironmentTestImplementation(configuration);
         ISink sink = env.getSink();
@@ -82,9 +81,7 @@ public class AgentBasedEnvironmentTest {
 
     @Test
     public void testGetSinkOverrideToStdOutFailFastOnImproperOverride() throws Exception {
-        PowerMockito.mockStatic(SystemWrapper.class);
-        // Will only override if this env is explicitly "true"
-        PowerMockito.when(SystemWrapper.getenv("WRITE_TO_STDOUT")).thenReturn("notABool");
+        configuration.setShouldWriteToStdout(false);
 
         testGetSinkWithDefaultEndpoint();
     }

--- a/src/test/java/software/amazon/cloudwatchlogs/emf/environment/AgentBasedEnvironmentTest.java
+++ b/src/test/java/software/amazon/cloudwatchlogs/emf/environment/AgentBasedEnvironmentTest.java
@@ -1,0 +1,91 @@
+package software.amazon.cloudwatchlogs.emf.environment;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import software.amazon.cloudwatchlogs.emf.config.Configuration;
+import software.amazon.cloudwatchlogs.emf.config.SystemWrapper;
+import software.amazon.cloudwatchlogs.emf.model.MetricsContext;
+import software.amazon.cloudwatchlogs.emf.sinks.AgentSink;
+import software.amazon.cloudwatchlogs.emf.sinks.ConsoleSink;
+import software.amazon.cloudwatchlogs.emf.sinks.Endpoint;
+import software.amazon.cloudwatchlogs.emf.sinks.ISink;
+
+import static org.junit.Assert.assertEquals;
+import static org.powermock.api.mockito.PowerMockito.mock;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest( {SystemWrapper.class, AgentBasedEnvironment.class} )
+public class AgentBasedEnvironmentTest {
+  public static class AgentBasedEnvironmentTestImplementation extends AgentBasedEnvironment {
+    protected AgentBasedEnvironmentTestImplementation(Configuration config) { super(config); }
+    @Override
+    public boolean probe() { return false; }
+    @Override
+    public String getType() { return null; }
+    @Override
+    public void configureContext(MetricsContext context) { }
+  }
+
+  private Configuration configuration;
+
+  @Before
+  public void setup() {
+    this.configuration = new Configuration();
+  }
+
+  @Test
+  public void testGetSinkWithDefaultEndpoint() throws Exception {
+    AgentSink mockedSink = mock(AgentSink.class);
+    PowerMockito.whenNew(AgentSink.class).withAnyArguments().then(invocation -> {
+      Endpoint endpoint = invocation.getArgument(2);
+      assertEquals(Endpoint.DEFAULT_TCP_ENDPOINT, endpoint);
+      return mockedSink;
+    });
+
+    AgentBasedEnvironment env = new AgentBasedEnvironmentTestImplementation(configuration);
+    ISink sink = env.getSink();
+
+    assertEquals(mockedSink, sink);
+  }
+
+  @Test
+  public void testGetSinkWithConfiguredEndpoint() throws Exception {
+    String endpointUrl = "http://configured-endpoint:1234";
+    configuration.setAgentEndpoint(endpointUrl);
+    AgentSink mockedSink = mock(AgentSink.class);
+    PowerMockito.whenNew(AgentSink.class).withAnyArguments().then(invocation -> {
+      Endpoint endpoint = invocation.getArgument(2);
+      assertEquals(Endpoint.fromURL(endpointUrl), endpoint);
+      return mockedSink;
+    });
+
+    AgentBasedEnvironment env = new AgentBasedEnvironmentTestImplementation(configuration);
+    ISink sink = env.getSink();
+
+    assertEquals(mockedSink, sink);
+  }
+
+  @Test
+  public void testGetSinkOverrideToStdOut() {
+    PowerMockito.mockStatic(SystemWrapper.class);
+    PowerMockito.when(SystemWrapper.getenv("WRITE_TO_STDOUT")).thenReturn("true");
+
+    AgentBasedEnvironment env = new AgentBasedEnvironmentTestImplementation(configuration);
+    ISink sink = env.getSink();
+
+    assertEquals(ConsoleSink.class, sink.getClass());
+  }
+
+  @Test
+  public void testGetSinkOverrideToStdOutFailFastOnImproperOverride() throws Exception {
+    PowerMockito.mockStatic(SystemWrapper.class);
+    // Will only override if this env is explicitly "true"
+    PowerMockito.when(SystemWrapper.getenv("WRITE_TO_STDOUT")).thenReturn("notABool");
+
+    testGetSinkWithDefaultEndpoint();
+  }
+}

--- a/src/test/java/software/amazon/cloudwatchlogs/emf/environment/AgentBasedEnvironmentTest.java
+++ b/src/test/java/software/amazon/cloudwatchlogs/emf/environment/AgentBasedEnvironmentTest.java
@@ -20,72 +20,72 @@ import static org.powermock.api.mockito.PowerMockito.mock;
 @RunWith(PowerMockRunner.class)
 @PrepareForTest( {SystemWrapper.class, AgentBasedEnvironment.class} )
 public class AgentBasedEnvironmentTest {
-  public static class AgentBasedEnvironmentTestImplementation extends AgentBasedEnvironment {
-    protected AgentBasedEnvironmentTestImplementation(Configuration config) { super(config); }
-    @Override
-    public boolean probe() { return false; }
-    @Override
-    public String getType() { return null; }
-    @Override
-    public void configureContext(MetricsContext context) { }
-  }
+    public static class AgentBasedEnvironmentTestImplementation extends AgentBasedEnvironment {
+        protected AgentBasedEnvironmentTestImplementation(Configuration config) { super(config); }
+        @Override
+        public boolean probe() { return false; }
+        @Override
+        public String getType() { return null; }
+        @Override
+        public void configureContext(MetricsContext context) { }
+    }
 
-  private Configuration configuration;
+    private Configuration configuration;
 
-  @Before
-  public void setup() {
-    this.configuration = new Configuration();
-  }
+    @Before
+    public void setup() {
+        this.configuration = new Configuration();
+    }
 
-  @Test
-  public void testGetSinkWithDefaultEndpoint() throws Exception {
-    AgentSink mockedSink = mock(AgentSink.class);
-    PowerMockito.whenNew(AgentSink.class).withAnyArguments().then(invocation -> {
-      Endpoint endpoint = invocation.getArgument(2);
-      assertEquals(Endpoint.DEFAULT_TCP_ENDPOINT, endpoint);
-      return mockedSink;
-    });
+    @Test
+    public void testGetSinkWithDefaultEndpoint() throws Exception {
+        AgentSink mockedSink = mock(AgentSink.class);
+        PowerMockito.whenNew(AgentSink.class).withAnyArguments().then(invocation -> {
+            Endpoint endpoint = invocation.getArgument(2);
+            assertEquals(Endpoint.DEFAULT_TCP_ENDPOINT, endpoint);
+            return mockedSink;
+        });
 
-    AgentBasedEnvironment env = new AgentBasedEnvironmentTestImplementation(configuration);
-    ISink sink = env.getSink();
+        AgentBasedEnvironment env = new AgentBasedEnvironmentTestImplementation(configuration);
+        ISink sink = env.getSink();
 
-    assertEquals(mockedSink, sink);
-  }
+        assertEquals(mockedSink, sink);
+    }
 
-  @Test
-  public void testGetSinkWithConfiguredEndpoint() throws Exception {
-    String endpointUrl = "http://configured-endpoint:1234";
-    configuration.setAgentEndpoint(endpointUrl);
-    AgentSink mockedSink = mock(AgentSink.class);
-    PowerMockito.whenNew(AgentSink.class).withAnyArguments().then(invocation -> {
-      Endpoint endpoint = invocation.getArgument(2);
-      assertEquals(Endpoint.fromURL(endpointUrl), endpoint);
-      return mockedSink;
-    });
+    @Test
+    public void testGetSinkWithConfiguredEndpoint() throws Exception {
+        String endpointUrl = "http://configured-endpoint:1234";
+        configuration.setAgentEndpoint(endpointUrl);
+        AgentSink mockedSink = mock(AgentSink.class);
+        PowerMockito.whenNew(AgentSink.class).withAnyArguments().then(invocation -> {
+            Endpoint endpoint = invocation.getArgument(2);
+            assertEquals(Endpoint.fromURL(endpointUrl), endpoint);
+            return mockedSink;
+        });
 
-    AgentBasedEnvironment env = new AgentBasedEnvironmentTestImplementation(configuration);
-    ISink sink = env.getSink();
+        AgentBasedEnvironment env = new AgentBasedEnvironmentTestImplementation(configuration);
+        ISink sink = env.getSink();
 
-    assertEquals(mockedSink, sink);
-  }
+        assertEquals(mockedSink, sink);
+    }
 
-  @Test
-  public void testGetSinkOverrideToStdOut() {
-    PowerMockito.mockStatic(SystemWrapper.class);
-    PowerMockito.when(SystemWrapper.getenv("WRITE_TO_STDOUT")).thenReturn("true");
+    @Test
+    public void testGetSinkOverrideToStdOut() {
+        PowerMockito.mockStatic(SystemWrapper.class);
+        PowerMockito.when(SystemWrapper.getenv("WRITE_TO_STDOUT")).thenReturn("true");
 
-    AgentBasedEnvironment env = new AgentBasedEnvironmentTestImplementation(configuration);
-    ISink sink = env.getSink();
+        AgentBasedEnvironment env = new AgentBasedEnvironmentTestImplementation(configuration);
+        ISink sink = env.getSink();
 
-    assertEquals(ConsoleSink.class, sink.getClass());
-  }
+        assertEquals(ConsoleSink.class, sink.getClass());
+    }
 
-  @Test
-  public void testGetSinkOverrideToStdOutFailFastOnImproperOverride() throws Exception {
-    PowerMockito.mockStatic(SystemWrapper.class);
-    // Will only override if this env is explicitly "true"
-    PowerMockito.when(SystemWrapper.getenv("WRITE_TO_STDOUT")).thenReturn("notABool");
+    @Test
+    public void testGetSinkOverrideToStdOutFailFastOnImproperOverride() throws Exception {
+        PowerMockito.mockStatic(SystemWrapper.class);
+        // Will only override if this env is explicitly "true"
+        PowerMockito.when(SystemWrapper.getenv("WRITE_TO_STDOUT")).thenReturn("notABool");
 
-    testGetSinkWithDefaultEndpoint();
-  }
+        testGetSinkWithDefaultEndpoint();
+    }
 }


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:* 

### Overview
I was looking through the [docs](https://github.com/awslabs/aws-embedded-metrics-node/blob/master/examples/README.md#ecs-and-fargate) and I noticed that if I have the `awslogs` log driver enabled for ECS and Fargate, I can just output the embedded metric logs to STDOUT. The only way I found to do this was to override the environment to `Local` and set the required dimensions with environment variables so they don't become `Unknown`.

Another issue with this method is that I lose all of the container context that the ECSEnvironment provides and I would like to have that.

This change introduces a new environment variable called `WRITE_TO_STDOUT` where if it's set to `true`, it will override the `AgentSink` and return a `ConsoleSink` in the `AgentBasedEnvironment` regardless of which `AgentBasedEnvironment` you use.

I went this direction because it felt like I would need to do some more potentially contentious refactoring around the environments to make an `ECSStdoutEnvironment` and would need to update the probe in the `ECSEnvironment` to verify that the cloudwatch agent is available (which I currently don't have the environment setup to test)

Lmk if you think otherwise or if you have another idea to get this done

### Testing
- unit testing
- ran the builds

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
