### PR TITLE
Feature: Adding Metric Aggregation in the form of a StatisticSet

### DIFF
--- a/src/main/java/software/amazon/cloudwatchlogs/emf/model/AggregationType.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/model/AggregationType.java
@@ -1,0 +1,33 @@
+/*
+ *   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package software.amazon.cloudwatchlogs.emf.model;
+
+public enum AggregationType {
+    LIST(0),
+    STATISTIC_SET(1),
+    UNKNOWN_TO_SDK_VERSION(-1);
+
+    private final int value;
+
+    AggregationType(final int newValue) {
+        value = newValue;
+    }
+
+    public int getValue() {
+        return this.value;
+    }
+}

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/model/StatisticSet.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/model/StatisticSet.java
@@ -1,0 +1,107 @@
+/*
+ *   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package software.amazon.cloudwatchlogs.emf.model;
+
+import java.util.LinkedList;
+import lombok.NonNull;
+import software.amazon.cloudwatchlogs.emf.exception.InvalidMetricException;
+
+/** Represents the StatisticSet of the EMF schema. */
+public class StatisticSet extends Metric<Statistics> {
+
+    StatisticSet(
+            Unit unit,
+            StorageResolution storageResolution,
+            double max,
+            double min,
+            int count,
+            double sum) {
+        this(unit, storageResolution, new Statistics(max, min, count, sum));
+    }
+
+    protected StatisticSet(
+            @NonNull String name,
+            Unit unit,
+            StorageResolution storageResolution,
+            Statistics statistics) {
+        this.unit = unit;
+        this.storageResolution = storageResolution;
+        this.values = statistics;
+        this.name = name;
+    }
+
+    StatisticSet(Unit unit, StorageResolution storageResolution, Statistics statistics) {
+        this.unit = unit;
+        this.storageResolution = storageResolution;
+        this.values = statistics;
+    }
+
+    @Override
+    protected LinkedList<Metric> serialize() throws InvalidMetricException {
+        // A statistic set is a complete metric that cannot be broken into smaller pieces therefore
+        // this metric will be the only one in the returned list
+        LinkedList<Metric> queue = new LinkedList<>();
+        queue.add(this);
+
+        return queue;
+    }
+
+    protected boolean isOversized() {
+        return false; // StatisticSets cannot be oversized according to CWL
+    }
+
+    @Override
+    public boolean hasValidValues() {
+        return values != null && values.isValid();
+    }
+
+    public static StatisticSetBuilder builder() {
+        return new StatisticSetBuilder();
+    }
+
+    public static class StatisticSetBuilder
+            extends Metric.MetricBuilder<Statistics, StatisticSetBuilder> {
+
+        @Override
+        protected StatisticSetBuilder getThis() {
+            return this;
+        }
+
+        public StatisticSetBuilder() {
+            values = new Statistics();
+        }
+
+        @Override
+        public StatisticSetBuilder addValue(double value) {
+            this.values.addValue(value);
+            return this;
+        }
+
+        public StatisticSetBuilder values(@NonNull Statistics values) {
+            this.values = values;
+            return this;
+        }
+
+        @Override
+        public StatisticSet build() {
+            if (name == null) {
+                return new StatisticSet(unit, storageResolution, values);
+            }
+            return new StatisticSet(name, unit, storageResolution, values);
+        }
+    }
+}

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/model/Statistics.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/model/Statistics.java
@@ -1,0 +1,90 @@
+/*
+ *   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package software.amazon.cloudwatchlogs.emf.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+class Statistics {
+    Statistics(double max, double min, int count, double sum) {
+        this.max = max;
+        this.min = min;
+        this.count = count;
+        this.sum = sum;
+        if (!isValid()) {
+            throw new IllegalArgumentException(
+                    "This is an impossible statistic set, there is no set of values that can create these statistics.");
+        }
+    }
+
+    Statistics() {
+        count = 0;
+        sum = 0.;
+    };
+
+    @JsonProperty("Max")
+    public Double max = Double.MIN_VALUE;
+
+    @JsonProperty("Min")
+    public Double min = Double.MAX_VALUE;
+
+    @JsonProperty("Count")
+    public int count;
+
+    @JsonProperty("Sum")
+    public Double sum;
+
+    int size() {
+        return 4;
+    }
+
+    void addValue(double value) {
+        count++;
+        sum += value;
+        if (value > max) {
+            max = value;
+        }
+        if (value < min) {
+            min = value;
+        }
+    }
+
+    /** @returns true if this object represents a possible non-empy set of real values. */
+    boolean isValid() {
+        return !(max < min
+                // Statistic set must not be empty or have a negative count
+                || (count <= 0)
+                // The max and min must be the same if there is only one value
+                || (count == 1 && Math.abs(max - min) > 1e-5)
+                // the sum must be less than or equal to the greatest possible value that could be
+                // created with this max, min and count
+                || min + max * (count - 1) < sum
+                // the sum must be greater than or equal to the smallest possible value that could
+                // be created with this max, min and count
+                || max + min * (count - 1) > sum);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Statistics that = (Statistics) o;
+        return count == that.count
+                && that.sum.equals(sum)
+                && that.max.equals(max)
+                && that.min.equals(min);
+    }
+}

--- a/src/test/java/software/amazon/cloudwatchlogs/emf/logger/MetricsLoggerTest.java
+++ b/src/test/java/software/amazon/cloudwatchlogs/emf/logger/MetricsLoggerTest.java
@@ -19,6 +19,7 @@ package software.amazon.cloudwatchlogs.emf.logger;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
@@ -36,6 +37,7 @@ import software.amazon.cloudwatchlogs.emf.exception.InvalidDimensionException;
 import software.amazon.cloudwatchlogs.emf.exception.InvalidMetricException;
 import software.amazon.cloudwatchlogs.emf.exception.InvalidNamespaceException;
 import software.amazon.cloudwatchlogs.emf.exception.InvalidTimestampException;
+import software.amazon.cloudwatchlogs.emf.model.AggregationType;
 import software.amazon.cloudwatchlogs.emf.model.DimensionSet;
 import software.amazon.cloudwatchlogs.emf.model.MetricsContext;
 import software.amazon.cloudwatchlogs.emf.model.StorageResolution;
@@ -529,6 +531,22 @@ class MetricsLoggerTest {
 
         logger.flush();
         assertFalse(sink.getLogEvents().get(0).contains("Count"));
+    }
+
+    @Test
+    void testDefaultAggregationType()
+            throws InvalidMetricException, DimensionSetExceededException, JsonProcessingException {
+        logger.setDefaultAggregationType(AggregationType.STATISTIC_SET);
+        assertEquals(AggregationType.STATISTIC_SET, logger.getDefaultAggregationType());
+
+        logger.putMetric("Count", 1);
+        logger.flush();
+
+        assertTrue(
+                sink.getContext()
+                        .serialize()
+                        .get(0)
+                        .contains("\"Count\":{\"Max\":1.0,\"Min\":1.0,\"Count\":1,\"Sum\":1.0}"));
     }
 
     private void expectDimension(String dimension, String value)

--- a/src/test/java/software/amazon/cloudwatchlogs/emf/model/MetricDefinitionTest.java
+++ b/src/test/java/software/amazon/cloudwatchlogs/emf/model/MetricDefinitionTest.java
@@ -17,19 +17,24 @@
 package software.amazon.cloudwatchlogs.emf.model;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Arrays;
 import java.util.Collections;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 class MetricDefinitionTest {
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testThrowExceptionIfNameIsNull() {
         MetricDefinition.MetricDefinitionBuilder builder = MetricDefinition.builder();
-        builder.setName(null);
+        assertThrows(
+                NullPointerException.class,
+                () -> {
+                    builder.setName(null);
+                });
     }
 
     @Test
@@ -106,7 +111,7 @@ class MetricDefinitionTest {
     @Test
     public void testAddValue() {
         MetricDefinition.MetricDefinitionBuilder builder =
-                MetricDefinition.builder().unit(Unit.MILLISECONDS).addValue(10).addValue(20);
+                MetricDefinition.builder().unit(Unit.MILLISECONDS).addValue(10);
         assertEquals(Collections.singletonList(10d), builder.getValues());
 
         builder.addValue(20);

--- a/src/test/java/software/amazon/cloudwatchlogs/emf/model/StatisticSetTest.java
+++ b/src/test/java/software/amazon/cloudwatchlogs/emf/model/StatisticSetTest.java
@@ -1,0 +1,158 @@
+/*
+ *   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package software.amazon.cloudwatchlogs.emf.model;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+public class StatisticSetTest {
+    @Test
+    public void testSerializeStatisticSetWithoutUnitWithHighStorageResolution()
+            throws JsonProcessingException {
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        StatisticSet statisticSet =
+                StatisticSet.builder()
+                        .storageResolution(StorageResolution.HIGH)
+                        .addValue(10)
+                        .name("Time")
+                        .build();
+        String metricString = objectMapper.writeValueAsString(statisticSet);
+
+        assertEquals("{\"Name\":\"Time\",\"Unit\":\"None\",\"StorageResolution\":1}", metricString);
+    }
+
+    @Test
+    public void testSerializeStatisticSetWithUnitWithoutStorageResolution()
+            throws JsonProcessingException {
+        ObjectMapper objectMapper = new ObjectMapper();
+        StatisticSet statisticSet =
+                StatisticSet.builder().unit(Unit.MILLISECONDS).name("Time").addValue(10).build();
+        String metricString = objectMapper.writeValueAsString(statisticSet);
+
+        assertEquals("{\"Name\":\"Time\",\"Unit\":\"Milliseconds\"}", metricString);
+    }
+
+    @Test
+    public void testSerializeStatisticSetWithoutUnitWithStandardStorageResolution()
+            throws JsonProcessingException {
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        StatisticSet statisticSet =
+                StatisticSet.builder()
+                        .storageResolution(StorageResolution.STANDARD)
+                        .name("Time")
+                        .addValue(10)
+                        .build();
+        String metricString = objectMapper.writeValueAsString(statisticSet);
+
+        assertEquals("{\"Name\":\"Time\",\"Unit\":\"None\"}", metricString);
+    }
+
+    @Test
+    public void testSerializeStatisticSetWithoutUnit() throws JsonProcessingException {
+        ObjectMapper objectMapper = new ObjectMapper();
+        StatisticSet statisticSet = StatisticSet.builder().name("Time").build();
+        String metricString = objectMapper.writeValueAsString(statisticSet);
+
+        assertEquals("{\"Name\":\"Time\",\"Unit\":\"None\"}", metricString);
+    }
+
+    @Test
+    public void testSerializeStatisticSet() throws JsonProcessingException {
+        ObjectMapper objectMapper = new ObjectMapper();
+        StatisticSet statisticSet =
+                StatisticSet.builder()
+                        .unit(Unit.MILLISECONDS)
+                        .storageResolution(StorageResolution.HIGH)
+                        .name("Time")
+                        .addValue(10)
+                        .build();
+        String metricString = objectMapper.writeValueAsString(statisticSet);
+
+        assertEquals(
+                "{\"Name\":\"Time\",\"Unit\":\"Milliseconds\",\"StorageResolution\":1}",
+                metricString);
+    }
+
+    @Test
+    public void testAddValues() {
+        StatisticSet.StatisticSetBuilder ssb = StatisticSet.builder();
+        ssb.addValue(10);
+        assertEquals(new Statistics(10., 10., 1, 10.), ssb.getValues());
+
+        ssb.addValue(20);
+        assertEquals(new Statistics(20., 10., 2, 30.), ssb.getValues());
+    }
+
+    @Test
+    public void testManyAddValues() {
+        StatisticSet.StatisticSetBuilder ssb = StatisticSet.builder();
+        for (int i = 1; i < 100; i++) {
+            ssb.addValue(i);
+            assertEquals(new Statistics(i, 1., i, i * (i + 1) / 2), ssb.getValues());
+        }
+    }
+
+    @Test
+    public void testBuildBuilder() {
+        StatisticSet statisticSet = StatisticSet.builder().addValue(10).build();
+        assertEquals(statisticSet.getValues(), statisticSet.getValues());
+
+        assertEquals(statisticSet.name, null);
+        statisticSet.setName("test");
+        assertEquals(statisticSet.name, "test");
+    }
+
+    @Test
+    public void testCreateImmutableStatisticSet() {
+        StatisticSet ss = new StatisticSet(Unit.NONE, StorageResolution.STANDARD, 10, 1, 11, 100);
+        assertEquals(new Statistics(10, 1, 11, 100), ss.getValues());
+    }
+
+    @Test
+    public void testImpossibleStatisticSet() {
+        // Sum too big
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new StatisticSet(Unit.NONE, StorageResolution.STANDARD, 10, 1, 2, 100));
+        // Sum too small
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new StatisticSet(Unit.NONE, StorageResolution.STANDARD, 10, 1, 3, 11));
+        // Count == 0 for non-zero set
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new StatisticSet(Unit.NONE, StorageResolution.STANDARD, 10, 1, 0, 100));
+        // min > max
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new StatisticSet(Unit.NONE, StorageResolution.STANDARD, 0, 1, 1, 0));
+        // Negative count
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new StatisticSet(Unit.NONE, StorageResolution.STANDARD, 10, 1, -1, 10));
+        // different max and min for 1 count
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new StatisticSet(Unit.NONE, StorageResolution.STANDARD, 10, 1, 1, 1));
+    }
+}


### PR DESCRIPTION
Introduces a new metric type called `StatisticSet` which will aggregate a set of metrics into the following properties: maximum, minimum, count, and sum. Users can create and log their own `StatisticSet` metric with the `StatisticSetBuilder` class or specify a metric's method when putting it into the `metricsLogger` and the `metricsLogger` will handle all aggregation.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
