### PR TITLE
Adds WARN log if retry attempts exceeded

### DIFF
--- a/src/main/java/software/amazon/cloudwatchlogs/emf/sinks/AgentSink.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/sinks/AgentSink.java
@@ -141,6 +141,7 @@ public class AgentSink implements ISink {
                     Thread.sleep(backoff.next());
                 }
             }
+            log.warn("Failed all attempts to write message to the socket.");
         }
     }
 }


### PR DESCRIPTION
There is currently DEBUG level logging when individual socket writes fail but there is no logging when all attempts are exhausted and the request is abandoned.

This change adds a log message in this scenario.
I've opted for WARN level as unlike the individual request failures, a total failure should probably be included most application logs as it is likely the agent is misconfigured in some way.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
