### PR TITLE
changed cloudwatch-agent to use ecr image instead of docker

### DIFF
--- a/canarytests/agent/container-definitions.json
+++ b/canarytests/agent/container-definitions.json
@@ -25,7 +25,7 @@
   },
   {
     "name": "cloudwatch-agent",
-    "image": "amazon/cloudwatch-agent:latest",
+    "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:latest",
     "logConfiguration": {
       "logDriver": "awslogs",
       "options": {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Changed the dockerhub `amazon/cloudwatch-agent:latest` image to use a similar image from ECR instead, the image `public.ecr.aws/cloudwatch-agent/cloudwatch-agent:latest`. This is due to an AppSec violation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
