### PR TITLE
fix: migrate canary base image from openjdk to amazoncorretto

### DIFF
--- a/canarytests/agent/Dockerfile
+++ b/canarytests/agent/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11-jdk-slim
+FROM amazoncorretto:11
 RUN mkdir /app
 COPY build/libs/*.jar /app/agent.jar
 ENV JAVA_OPTS=""


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

openjdk:11-jdk-slim was deprecated by Docker Hub in 2022 and is based on Debian Buster (EOL).

Migrate to amazoncorretto:11 which is actively maintained by Amazon and receives regular security patches.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
